### PR TITLE
Add GraphQL policy, populate fields in user's session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,63 +7,88 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Policy for other apps to call this app's GraphQL routes
+- `organization`, `costCenter`, `collections` are now populated in user's session
+
 ## [1.4.2] - 2021-09-07
 
 ### Added
+
 - Getting `priceTables` from `vtex.b2b-organizations-graphql`
 
 ## [1.4.1] - 2021-09-03
 
 - Ignore errors when using `withUserPermissions`
+
 ## [1.4.0] - 2021-08-31
 
 ### Added
+
 - Organization and Cost Center dropdown
 - GraphQL Directive `withUserPermissions`
+
 ## [1.3.3] - 2021-08-16
 
 ## [1.3.2] - 2021-08-13
 
 ### Fixed
+
 - MD Schema
+
 ## [1.3.1] - 2021-08-13
 
 ### Added
+
 - Exception for `vtex.storefront-permissions-ui` requests
 
 ## [1.3.0] - 2021-08-12
 
 ### Added
+
 - Exported component `StorefrontPermissions` to be imported by `vtex.admin-customers`
 
 ### Fixed
+
 - Duplicated Role
 - License Manager insertion for new vtex users
+
 ## [1.2.0] - 2021-08-09
 
 ### Changed
+
 - Turning it into a backend layer app
+
 ## [1.1.0] - 2021-08-02
 
 ### Added
+
 - new Graphql query `hasUsers`
+
 ## [1.0.1] - 2021-08-02
 
 ### Fixed
+
 - User search at the admin (Dependency change)
 
 ## [1.0.0] - 2021-08-02
 
 ### Removed
+
 - `billingOpstions` from `manifest.json`
 - Option to **Create** and **Delete** roles from the Admin
 
 ### Added
+
 - Roles autosync from dependent Apps
 
 ### Changed
+
 - `checkUserPermission` return structure
+
 ## [0.0.2] - 2021-07-26
 
 ### Removed
+
 - `totalNumberOfUsers` from graqhql query

--- a/node/directives/withSender.ts
+++ b/node/directives/withSender.ts
@@ -9,7 +9,10 @@ export class WithSender extends SchemaDirectiveVisitor {
     const { resolve = defaultFieldResolver } = field
 
     field.resolve = async (root: any, args: any, context: any, info: any) => {
-      context.vtex.sender = context?.graphql?.query?.senderApp ?? null
+      context.vtex.sender =
+        context?.graphql?.query?.senderApp ??
+        context?.graphql?.query?.extensions?.persistedQuery?.sender ??
+        null
 
       return resolve(root, args, context, info)
     }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -47,7 +47,10 @@ export const resolvers = {
           organization: {
             value: '',
           },
-          costcenter: {
+          costCenter: {
+            value: '',
+          },
+          collections: {
             value: '',
           },
           priceTables: {
@@ -69,6 +72,8 @@ export const resolvers = {
         console.log('USER =>', user)
 
         if (user?.orgId) {
+          res['storefront-permissions'].organization.value = user.orgId
+
           const organizationResponse: any = await graphqlServer.query(
             QUERIES.getOrganizationById,
             { id: user.orgId },
@@ -81,6 +86,19 @@ export const resolvers = {
           )
 
           if (
+            organizationResponse?.data?.getOrganizationById?.collections?.length
+          ) {
+            const collectionsArray =
+              organizationResponse.data.getOrganizationById.collections.map(
+                (collection: any) => collection.id
+              )
+
+            res[
+              'storefront-permissions'
+            ].collections.value = `${collectionsArray.join(';')};`
+          }
+
+          if (
             organizationResponse?.data?.getOrganizationById?.priceTables?.length
           ) {
             res[
@@ -89,12 +107,10 @@ export const resolvers = {
               ';'
             )};`
           }
+        }
 
-          console.log('organizationResponse =>', organizationResponse)
-          // res['storefront-permissions'].priceTables.value = ''
-          // res.public.facets.value = ''
-          // res['storefront-permissions'].organization.value = ''
-          // res['storefront-permissions'].costcenter.value = ''
+        if (user?.costId) {
+          res['storefront-permissions'].costCenter.value = user.costId
         }
       }
 

--- a/node/typings.d.ts
+++ b/node/typings.d.ts
@@ -8,7 +8,11 @@ interface ReqContext {
 }
 
 interface Logger {
-  log(content: string, level: LogLevel, details?: {}): PromiseLike<void>
+  log(
+    content: string,
+    level: LogLevel,
+    details?: Record<string, unknown>
+  ): PromiseLike<void>
 }
 
 interface OperationState {
@@ -24,7 +28,10 @@ interface OperationData {
   cookie: string
 }
 
-type ProcessPaymentStep = (state: OperationState, next: () => Promise<void>) => Promise<void>
+type ProcessPaymentStep = (
+  state: OperationState,
+  next: () => Promise<void>
+) => Promise<void>
 
 type LogLevel = 'info' | 'error' | 'warning'
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1487,7 +1487,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/policies.json
+++ b/policies.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "resolve-graphql",
+    "description": "Allows access to resolve a graphql request",
+    "statements": [
+      {
+        "actions": ["post", "get"],
+        "effect": "allow",
+        "resources": [
+          "vrn:vtex.storefront-permissions:{{region}}:{{account}}:{{workspace}}:/_v/graphql"
+        ]
+      }
+    ]
+  }
+]

--- a/vtex.session/configuration.json
+++ b/vtex.session/configuration.json
@@ -4,7 +4,12 @@
       "authentication": ["storeUserEmail"]
     },
     "output": {
-      "storefront-permissions": ["organization", "costcenter", "priceTables"]
+      "storefront-permissions": [
+        "organization",
+        "costCenter",
+        "priceTables",
+        "collections"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Added

- Policy for other apps to call this app's GraphQL routes
- `organization`, `costCenter`, `collections` are now populated in user's session