### PR TITLE
[B2BORG-15] Adding search-segments apps as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `vtex.search-session`, `vtex.search-segment-graphql` and `vtex.search-segment-resolver` as dependency
+
 ## [1.5.2] - 2021-10-13
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,10 @@
   "dependencies": {
     "vtex.profile-session": "0.x",
     "vtex.styleguide": "9.x",
-    "vtex.graphql-server": "1.x"
+    "vtex.graphql-server": "1.x",
+    "vtex.search-session": "0.x",
+    "vtex.search-segment-graphql": "0.x",
+    "vtex.search-segment-resolver": "0.x"
   },
   "builders": {
     "configuration": "0.x",


### PR DESCRIPTION
**What problem is this solving?**
`vtex.search-session`, `vtex.search-segment-graphql` and `vtex.search-segment-resolver` as dependency to have its resources always available when we need


<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**
- First access this page [https://collection--sandboxusdev.myvtex.com/food-and-beverage](https://collection--sandboxusdev.myvtex.com/food-and-beverage)

- Check the products
- Now log in using `wender.lima@gmail.com` and `Wender@123` 
- Once logged, refresh the page

This user only have access to products under Green collection

**Screenshots or example usage:**
![image](https://user-images.githubusercontent.com/24723/137179261-8f61e653-5346-4212-ae56-8816c7f56f88.png)
