### PR TITLE
[B2BORG-39] Fix bug when storing features from multiple modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- When syncing roles and features, new modules are now added to existing modules instead of replacing them
+
 ## [1.9.0] - 2021-11-09
 
 ### Added
 
 - Optional `permissionId` variables for `listUsers` query
 
-
 ## [1.8.2] - 2021-11-02
 
 ### Fixed
+
 - Not loading saved roles from checkPermissions
+
 ## [1.8.1] - 2021-10-28
 
 ### Fixed
+
 - Slug being updated if a Role name is changed
 
 ## [1.8.0] - 2021-10-26

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "1.9.0",
   "dependencies": {
-    "@vtex/api": "6.45.3",
+    "@vtex/api": "6.45.6",
     "co-body": "^6.0.0",
     "jsonwebtoken": "^8.5.0",
     "qs": "^6.9.4",
@@ -22,7 +22,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.3",
+    "@vtex/api": "6.45.6",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/Mutations/Roles.ts
+++ b/node/resolvers/Mutations/Roles.ts
@@ -116,7 +116,7 @@ export const syncRoles = async (ctx: Context) => {
 
       currRole = {
         ...roles[roleIndex],
-        features: newModules,
+        features: currModules,
       }
     }
 

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -170,7 +170,7 @@ export const listUsers = async (
     organizationId = '',
     costCenterId = '',
     roleId = '',
-  }: { organizationId: string; costCenterId: string, roleId: string },
+  }: { organizationId: string; costCenterId: string; roleId: string },
   ctx: Context
 ) => {
   const {
@@ -180,8 +180,6 @@ export const listUsers = async (
   let res: any = []
 
   const whereArray: string[] = []
-
-  console.log('args ==>', {organizationId, costCenterId, roleId})
 
   if (organizationId) {
     whereArray.push(`orgId=${organizationId}`)

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -190,10 +190,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.3":
-  version "6.45.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.3.tgz#fe7d08adb4eab1fda5e34143cc6302a4c5aa5f52"
-  integrity sha512-kiD7We1TCKDyBdpYoh2Se3An+jTJRUzXGNpKifoDZylWQ1PyIx+3oL5ZAif9InlY3uJkfEisSAI6nxoKTgvPfw==
+"@vtex/api@6.45.6":
+  version "6.45.6"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
+  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1492,7 +1492,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**

If two or more modules (i.e. apps) defined features (i.e. permissions) using the storefront-permissions builder, only one module's features would show up when querying the current user's permissions. Essentially, when a new module was added into the mix, only the new module's permissions would be returned. 

This was caused by a bug in a single line of code, where instead of saving the combined array of all modules and features, only the "new" module and its features were being saved. See  `node/resolvers/Mutations/Roles.ts` for the fixed line of code.

**How should this be manually tested?**

Linked here: https://quotes--sandboxusdev.myvtex.com/admin/app/storefront-permissions/role/f2a38526-f3bd-11eb-82ac-12fda6a1f41f
Note that permissions are correctly populated for both B2B Quotes and B2B Organizations.
