### PR TITLE
[B2BORG-19] Prevent login for inactive orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Prevent login for users in inactive organizations by throwing error in `setProfile` route handler
+
 ## [1.9.1] - 2021-11-22
 
 ### Fixed


### PR DESCRIPTION
**What problem is this solving?**

If a user is in an inactive organization, we decided that they should be unable to login. This PR implements that behavior by checking the organization's status while modifying the user's session and throwing a 403 Forbidden error if the status is equal to "inactive".  

**How should this be manually tested?**

Linked in https://quotes--sandboxusdev.myvtex.com

Interestingly, when the app throws an error and login is blocked, the session request is retried on every page reload. The end result is still the same, but it's something to be aware of.