### PR TITLE
Don't throw error if user's role has no enabled permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `checkUserPermissions` query will no longer throw an error if the user's role has no enabled permissions for the app making the request
+
 ## [1.10.0] - 2021-12-21
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -111,16 +111,5 @@
       }
     }
   ],
-  "settingsSchema": {
-    "title": "B2B Admin",
-    "type": "object",
-    "properties": {
-      "masterEmail": {
-        "title": "Main admin email",
-        "description": "Only the user with this email address can do the initial setup",
-        "type": "string"
-      }
-    }
-  },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -268,14 +268,6 @@ export const checkUserPermission = async (
           return feature.module === module
         })
 
-        if (
-          !currentModule &&
-          module !== 'vtex.storefront-permissions-ui' &&
-          !skipError
-        ) {
-          throw new Error(`Role not found for module ${module}`)
-        }
-
         ret = {
           role: userRole,
           permissions: currentModule?.features ?? [],


### PR DESCRIPTION
**What problem is this solving?**

`checkUserPermissions` query was throwing an error if the user's role had no enabled permissions for the app making the request. For example, the Buyer role has no enabled permissions for `vtex.b2b-organizations`, but the query should still be able to be used to query the user's role. This PR allows the query to succeed in this scenario (the `permissions` field will be an empty array).

**How should this be manually tested?**

Linked in https://quotes--sandboxusdev.myvtex.com