### PR TITLE
Check if email already exists in MD when adding a new user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- When adding a new user, check if their email already exists in MD
+
 ## [1.12.0] - 2022-01-18
 
 ### Added
+
 - `checkImpersonation` Graphql query
+
 ## [1.11.0] - 2022-01-10
 
 ### Added
+
 - `impersonateUser` mutation
 
 ## [1.10.1] - 2022-01-04


### PR DESCRIPTION
**What problem is this solving?**

Previously, an organization admin was able to use the "Add User" form to add the same user multiple times. They could add the same user with two different roles, or put the same user in two different cost centers, etc. Behind the scenes, storefront-permissions was creating two records that both pointed to the same CL ID. This was because there was no validation to see if the user (specifically, the email address) already existed in the storefront-permissions MD table.

This PR adds validation for this. If the app finds an existing record for the "new" user's email, it will update that record rather than creating a brand new record.

**How should this be manually tested?**

Linked in https://quotes--sandboxusdev.myvtex.com . Try going to My Account - My Organization and adding the same user twice with different roles. The second "addition" will now change the role of the first entry rather than creating a second entry.