### PR TITLE
Added Session Watcher toggle setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Better logging
+- Session Watcher toggle setting
 ## [1.12.1] - 2022-01-21
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -179,3 +179,10 @@ mutation impersonateUser($userId: ID)
   }
 }
 ```
+
+### Troubleshooting
+
+By default the app settings has the Session Watcher active, it's used to detect changes to authentication, orderFormId or impersonation request. When active, sets priceTable, Collection, Cart Settings, Organizations and Cost Center to the session
+
+If loaded via dependency, it may cause unecessary use of resources, to turn this feature off, head over to `{accountName}.myvtex.com/admin/apps/vtex.storefront-permissions@1.x/setup/` uncheck the **YES** option and click **SAVE**
+

--- a/manifest.json
+++ b/manifest.json
@@ -118,5 +118,23 @@
       }
     }
   ],
+  "settingsSchema": {
+    "title": "Storefront Permissions",
+    "type": "object",
+    "properties": {
+      "sessionWatcher": {
+        "type": "object",
+        "title": "Watch session changes",
+        "description": "Detects changes to authentication, orderFormId or impersonation request. When active, sets priceTable, Collection, Cart Settings, Organizations and Cost Center to the session",
+        "properties": {
+          "active": {
+            "type": "boolean",
+            "title": "Yes",
+            "default": true
+          }
+        }
+      }
+    }
+  },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -173,7 +173,7 @@ export const resolvers = {
         if (email) {
           const [user]: any = await getUserByEmail(null, { email }, ctx).catch(
             (error) => {
-              logger.error({ message: 'setProfile.getUserByEmailError', error })
+              logger.warn({ message: 'setProfile.getUserByEmailError', error })
             }
           )
 

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -119,7 +119,7 @@ export const resolvers = {
       } = ctx
 
       const settings = await apps.getAppSettings(getAppId()).catch((error) => {
-        logger.error({ message: 'Error getting app settings', error })
+        logger.error({ message: 'setProfile.getAppSettingsError', error })
       })
 
       const res = {
@@ -161,7 +161,7 @@ export const resolvers = {
           const profile: any = await profileSystem
             .getProfileInfo(impersonate)
             .catch((error) => {
-              logger.error({ message: 'Error getting user profile', error })
+              logger.error({ message: 'setProfile.getProfileInfoError', error })
             })
 
           if (profile) {
@@ -173,7 +173,7 @@ export const resolvers = {
         if (email) {
           const [user]: any = await getUserByEmail(null, { email }, ctx).catch(
             (error) => {
-              logger.error({ message: 'Error getting user by email', error })
+              logger.error({ message: 'setProfile.getUserByEmailError', error })
             }
           )
 
@@ -183,7 +183,7 @@ export const resolvers = {
               { id: user.clId },
               ctx
             ).catch((error) => {
-              logger.error({ message: 'Error getting user by id', error })
+              logger.error({ message: 'setProfile.getUserByIdError', error })
             })
 
             if (clUser && orderFormId) {
@@ -191,7 +191,7 @@ export const resolvers = {
                 .updateOrderFormProfile(orderFormId, clUser)
                 .catch((error) => {
                   logger.error({
-                    message: 'Error updating orderForm clientProfileData',
+                    message: 'setProfile.updateOrderFormProfileError',
                     error,
                   })
                 })
@@ -213,7 +213,10 @@ export const resolvers = {
                 }
               )
               .catch((error) => {
-                logger.error({ message: 'Error getting organization', error })
+                logger.error({
+                  message: 'setProfile.graphqlGetOrganizationById',
+                  error,
+                })
               })
 
             // prevent login if org is inactive
@@ -256,7 +259,7 @@ export const resolvers = {
                 })
                 .catch((error) => {
                   logger.error({
-                    message: 'Error updating orderForm marketingData',
+                    message: 'setProfile.updateOrderFormMarketingDataError',
                     error,
                   })
                 })
@@ -276,7 +279,10 @@ export const resolvers = {
                   }
                 )
                 .catch((error) => {
-                  logger.error({ message: 'Error getting cost center', error })
+                  logger.error({
+                    message: 'setProfile.graphqlGetCostCenterById',
+                    error,
+                  })
                 })
 
               if (
@@ -291,7 +297,7 @@ export const resolvers = {
                   .updateOrderFormShipping(orderFormId, { address })
                   .catch((error) => {
                     logger.error({
-                      message: 'Error updating orderForm shippingData',
+                      message: 'setProfile.updateOrderFormShippingError',
                       error,
                     })
                   })


### PR DESCRIPTION
**What problem is this solving?**
When an Account indirectly depend o Storefront Permissions, it unnecessarily triggers actions on the Session
This version adds a new App Setting that can be used to disable the session watcher

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**
Access the App Settings from the admin [/admin/apps/vtex.storefront-permissions@1.x/setup/](https://wender--sandboxusdev.myvtex.com/admin/apps/vtex.storefront-permissions@1.x/setup/)

Make sure it's ON

Log in using **wender.lima@gmail.com** `Wender@123`

Access [https://wender--sandboxusdev.myvtex.com/api/sessions?items=*](https://wender--sandboxusdev.myvtex.com/api/sessions?items=*) to check if `storefront-permissions` namespace is defined
![image](https://user-images.githubusercontent.com/24723/152045668-555fc225-9dcb-49d8-a854-6a398f78400b.png)

Log out and check the `storefront-permissions` namespace again, it should not be there anymore

After that, go back to the App Settings page, turn OFF and save it

Repeat the Login, Check session, `storefront-permissions` namespace should not exist even after login

**Screenshots or example usage:**
![image](https://user-images.githubusercontent.com/24723/152044888-7dee1118-1c3e-4857-a7f7-003610afb7e2.png)
