### PR TITLE
Added graphql session watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- GraphQL query `getSessionWatcher` and mutation `sessionWatcher`
 ## [1.12.2] - 2022-02-01
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,7 +150,7 @@ query checkImpersonation {
 }
 ```
 
-The response will be a boolean
+The response
 
 ```JSON
 {
@@ -166,7 +166,27 @@ The response will be a boolean
 }
 ```
 
+`getSessionWatcher`
+
+```graphql
+query getSessionWatcher {
+  getSessionWatcher
+}
+```
+
+The response will be a boolean
+
+```JSON
+{
+  "data": {
+    "getSessionWatcher": false
+  }
+}
+```
+
 ### Graphql mutation
+
+`impersonateUser`
 
 Use `userId` to impersonate, to remove impersonation send an empty `userId` instead
 
@@ -176,6 +196,28 @@ mutation impersonateUser($userId: ID)
   impersonateUser(userId: $userId) {
     status
     message
+  }
+}
+```
+
+
+`sessionWatcher`
+
+**Storefront Permissions** detects changes to the user authentication to trigger changes to its Cart and Navigation (Price Tables, Collections, Profile, Shipping)
+If your account is not using `vtex.organizations` you may want to disable the Session Watcher to avoid unnecessary operations
+
+```graphql
+mutation setSessionWatcher {
+  sessionWatcher(active: false)
+}
+```
+
+The response will be a boolean with `true` for a successful operation or `false` for a failure
+
+```JSON
+{
+  "data": {
+    "sessionWatcher": true
   }
 }
 ```

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -34,6 +34,7 @@ type Query {
     @withSession
     @withSender
     @cacheControl(scope: PRIVATE)
+  getSessionWatcher: Boolean @cacheControl(scope: PRIVATE)
 }
 
 type UserImpersonation {
@@ -50,7 +51,7 @@ type UserPermissions {
 }
 
 type Mutation {
-  saveAppSettings: MutationResponse @cacheControl(scope: PRIVATE)
+  sessionWatcher(active: Boolean!): Boolean @cacheControl(scope: PRIVATE)
   # Roles
   saveRole(
     id: ID

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getAppId } from '../Queries/Settings'
+
+export const sessionWatcher = async (_: any, params: any, ctx: Context) => {
+  const {
+    clients: { vbase },
+    vtex: { logger },
+  } = ctx
+
+  const app: string = getAppId()
+
+  const settings: any = await vbase.getJSON('b2b_settings', app).catch(() => {
+    return {}
+  })
+
+  const { active } = params
+
+  settings.sessionWatcher = { active }
+
+  const save = await vbase
+    .saveJSON('b2b_settings', app, settings)
+    .then(() => true)
+    .catch((error) => {
+      logger.error({
+        message: 'sessionWatcher.saveSessionWatcherError',
+        error,
+      })
+
+      return false
+    })
+
+  return save
+}

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -2,7 +2,7 @@ import { syncRoles } from '../Mutations/Roles'
 import schemas from '../../mdSchema'
 import { toHash } from '../../utils'
 
-const getAppId = (): string => {
+export const getAppId = (): string => {
   const app = process.env.VTEX_APP_ID
   const [appName] = String(app).split('@')
 
@@ -61,7 +61,7 @@ export const getAppSettings = async (_: any, __: any, ctx: Context) => {
         }
       })
 
-    await vbase.saveJSON('b2b_settigns', app, settings)
+    await vbase.saveJSON('b2b_settings', app, settings)
   }
 
   const roles: any = await syncRoles(ctx).catch(() => [])
@@ -69,4 +69,22 @@ export const getAppSettings = async (_: any, __: any, ctx: Context) => {
   settings.adminSetup.roles = !!roles.length
 
   return settings
+}
+
+export const getSessionWatcher = async (_: any, __: any, ctx: Context) => {
+  const {
+    clients: { vbase },
+  } = ctx
+
+  const app: string = getAppId()
+
+  const settings: any = await vbase.getJSON('b2b_settings', app).catch(() => {
+    return {}
+  })
+
+  try {
+    return settings?.sessionWatcher?.active ?? true
+  } catch (e) {
+    return { status: 'error', message: e }
+  }
 }


### PR DESCRIPTION
**What problem is this solving?**
When an Account indirectly depend o Storefront Permissions, it unnecessarily triggers actions on the Session
This version adds a new App Setting (vbase) that can be used to disable the session watcher

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**
[Using GraphiQL interface ](https://wender--sandboxusdev.myvtex.com/_v/private/vtex.storefront-permissions@1.12.2/graphiql/v1?query=query%20getSessionWatcher%20%7B%0A%20%20getSessionWatcher%0A%7D%0A%0Amutation%20setSessionWatcher%20%7B%0A%20%20sessionWatcher(active%3A%20false)%0A%7D%0A&operationName=setSessionWatcher)

Run que query 
```graqhql
query getSessionWatcher {
  getSessionWatcher
}
```
Make sure it is `true`

Log in using **wender.lima@gmail.com** `Wender@123`

Access [https://wender--sandboxusdev.myvtex.com/api/sessions?items=*](https://wender--sandboxusdev.myvtex.com/api/sessions?items=*) to check if `storefront-permissions` namespace is defined
![image](https://user-images.githubusercontent.com/24723/152045668-555fc225-9dcb-49d8-a854-6a398f78400b.png)

Log out and check the `storefront-permissions` namespace again, it should not be there anymore

After that, go back to the GraphiQL interface and change the active to false
```graphql
mutation setSessionWatcher {
  sessionWatcher(active: false)
}
```

Repeat the Login, Check session, `storefront-permissions` namespace should not exist even after login

