### PR TITLE
Fix on VB existing MD database

### DIFF
--- a/node/resolvers/Mutations/Roles.ts
+++ b/node/resolvers/Mutations/Roles.ts
@@ -20,11 +20,12 @@ export const saveRole = async (_: any, params: any, ctx: Context) => {
     }
 
     const roles = await searchRoles(null, ctx)
+    const role = roles.find((item) => item.slug === data.slug)
 
     await vbase.saveJSON('b2b_roles', rolesVbaseId, [
       ...roles.filter((item) => item.slug !== data.slug),
       {
-        id: data.slug,
+        id: role?.id ? role.id : data.id ?? data.slug,
         name,
         locked,
         slug: data.slug,

--- a/node/resolvers/Queries/Roles.ts
+++ b/node/resolvers/Queries/Roles.ts
@@ -55,6 +55,10 @@ export const searchRoles = async (_: any, ctx: Context) => {
 }
 
 export const getRole = async (_: any, params: any, ctx: Context) => {
+  const {
+    vtex: { logger },
+  } = ctx
+
   try {
     const { id, slug } = params
 
@@ -64,6 +68,11 @@ export const getRole = async (_: any, params: any, ctx: Context) => {
 
     return role
   } catch (e) {
+    logger.error({
+      message: 'Roles.getRole',
+      e,
+    })
+
     return { status: 'error', message: e }
   }
 }

--- a/node/resolvers/Queries/Roles.ts
+++ b/node/resolvers/Queries/Roles.ts
@@ -70,7 +70,7 @@ export const getRole = async (_: any, params: any, ctx: Context) => {
   } catch (e) {
     logger.error({
       message: 'Roles.getRole',
-      e,
+      error: e,
     })
 
     return { status: 'error', message: e }

--- a/node/resolvers/Queries/Roles.ts
+++ b/node/resolvers/Queries/Roles.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { syncRoles } from '../Mutations/Roles'
-import { currentRoleNames, rolesVbaseId } from '../../utils'
+import { currentRoleNames, currentSchema, rolesVbaseId } from '../../utils'
 import { getUserByRole } from './Users'
 
 const sorting = (a: any, b: any) => (a.name > b.name ? 1 : -1)
+const config: any = currentSchema('b2b_roles')
 
 const getDefaultRoles = (locale: string) => {
   const roleNames = currentRoleNames(locale)
@@ -24,7 +25,7 @@ const getDefaultRoles = (locale: string) => {
 
 export const searchRoles = async (_: any, ctx: Context) => {
   const {
-    clients: { vbase },
+    clients: { vbase, masterdata },
   } = ctx
 
   try {
@@ -35,7 +36,18 @@ export const searchRoles = async (_: any, ctx: Context) => {
     return roles
   } catch (e) {
     if (e?.response?.status === 404) {
-      return getDefaultRoles(ctx.vtex.tenant?.locale ?? '')
+      const options: any = {
+        dataEntity: config.name,
+        fields: ['id', 'name', 'features', 'locked', 'slug'],
+        schema: config.version,
+        pagination: { page: 1, pageSize: 50 },
+      }
+
+      const roles = await masterdata.searchDocuments(options)
+
+      return !roles || roles.length === 0
+        ? getDefaultRoles(ctx.vtex.tenant?.locale ?? '')
+        : roles
     }
 
     throw new Error(e)
@@ -44,11 +56,11 @@ export const searchRoles = async (_: any, ctx: Context) => {
 
 export const getRole = async (_: any, params: any, ctx: Context) => {
   try {
-    const { id } = params
+    const { id, slug } = params
 
-    const role: any = (await searchRoles(null, ctx)).find(
-      (item: any) => item.id === id
-    )
+    const role: any = id
+      ? (await searchRoles(null, ctx)).find((item: any) => item.id === id)
+      : (await searchRoles(null, ctx)).find((item: any) => item.slug === slug)
 
     return role
   } catch (e) {
@@ -57,7 +69,11 @@ export const getRole = async (_: any, params: any, ctx: Context) => {
 }
 
 export const hasUsers = async (_: any, params: any, ctx: Context) => {
-  const role: any = await getRole(null, { id: params.slug || params.id }, ctx)
+  const role: any = await getRole(
+    null,
+    { id: params.id, slug: params.slug },
+    ctx
+  )
 
   if (role?.id) {
     const usersByRole: any = await getUserByRole(_, { id: role.id }, ctx)

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -34,7 +34,7 @@ export const currentSchema = (entity: string) => {
   })
 }
 
-export const rolesVbaseId = 'allRoles'
+export const rolesVbaseId = 'allRolesVbId'
 
 export const currentRoleNames = (locale: any) => {
   return roleNames[locale] ?? roleNames['en-US']


### PR DESCRIPTION
**What problem is this solving?**

When the MD roles database already exists, the roles are being rewritten and the permissions are lost.

[https://artur3--b2bstoreqa.myvtex.com/admin/storefront-permissions/roles/list](https://artur3--b2bstoreqa.myvtex.com/admin/storefront-permissions/roles/list)

### Solution

When the data from VB is returning empty it checks on MD if it exists then return them or the default roles.
