### PR TITLE
[PERMISSION-22] Improve impersonation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `checkUserPermissions` will now always return the "parent" user's role and permissions regardless of impersonation
+- If impersonating a user, their organization and cost center will be applied to the session (and therefore their price list, catalog, etc)
+
 ## [1.13.2] - 2022-02-28
 
 ## [1.13.1] - 2022-02-25
 
 ### Fixed
+
 - Changed the role handling from masterdata to vbase to avoid duplicated entries
 
 ## [1.13.0] - 2022-02-02
 
 ### Added
+
 - GraphQL query `getSessionWatcher` and mutation `sessionWatcher`
+
 ## [1.12.2] - 2022-02-01
 
 ### Added
+
 - Better logging
+
 ## [1.12.1] - 2022-01-21
 
 ### Fixed

--- a/node/index.ts
+++ b/node/index.ts
@@ -14,7 +14,7 @@ import { schemaDirectives } from './directives'
 import { Clients } from './clients'
 import { resolvers } from './resolvers'
 
-const TIMEOUT_MS = 2000
+const TIMEOUT_MS = 4000
 
 const defaultClientOptions = {
   retries: 1,

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -214,11 +214,13 @@ export const impersonateUser = async (_: any, params: any, ctx: Context) => {
   const {
     clients: { session },
     cookies,
+    request,
   } = ctx
 
   const { userId } = params
 
-  const sessionCookie = cookies.get('vtex_session')
+  const sessionCookie =
+    cookies.get('vtex_session') ?? request.header?.sessiontoken
 
   try {
     await session.updateSession('impersonate', userId, [], sessionCookie)

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -239,16 +239,16 @@ export const checkUserPermission = async (
     throw new Error('Sender not available, make sure the query is private')
   }
 
-  const user = sessionData?.namespaces?.profile
+  const user = sessionData?.namespaces?.authentication
 
   let ret = null
 
-  if (user?.email?.value && sender) {
+  if (user?.storeUserEmail?.value && sender) {
     const module = removeVersionFromAppId(sender)
 
     const userData: any = await getUserByEmail(
       _,
-      { email: user.email.value },
+      { email: user.storeUserEmail.value },
       ctx
     )
 

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -149,7 +149,7 @@ export const resolvers = {
         const body: any = await json(ctx.req)
 
         const impersonate = body?.public?.impersonate?.value ?? null
-        const email = body?.authentication?.storeUserEmail?.value ?? null
+        let email = body?.authentication?.storeUserEmail?.value ?? null
         const orderFormId = body?.checkout?.orderFormId?.value ?? null
 
         if (impersonate) {
@@ -162,6 +162,7 @@ export const resolvers = {
           if (profile) {
             res['storefront-permissions'].storeUserId.value = profile.userId
             res['storefront-permissions'].storeUserEmail.value = profile.email
+            email = profile.email
           }
         }
 


### PR DESCRIPTION
**What problem is this solving?**

Our team discussed the impersonation feature and came to the following conclusions:

- impersonation should apply the impersonated user's organization and cost center to your session
- your original role and permissions should NOT be replaced with the impersonated user's role/permissions

This PR enables the above functionality. I also made an adjustment to allow `impersonateUser` to receive a forwarded session token, so that `b2b-organizatons-graphql` can apply a permissions check before executing the mutation. 

**How should this be manually tested?**

This new version along with new versions of `b2b-organizations` and `b2b-organizations-graphql` is linked here: https://b2bsuite--sandboxusdev.myvtex.com

To impersonate a user, login as someone with impersonation permissions (i.e. a sales role or org admin), then go to My Organization and click the three dots next to a user in the user list. 