### PR TITLE
B2BCHCKOUT-18 - Unable to make a payment in b2b store - Getting Error [PFA]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Fix on shipping data payload
+
 ## [1.14.0] - 2022-03-08
 
 ### Changed

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -290,7 +290,10 @@ export const resolvers = {
                   costCenterResponse.data.getCostCenterById.addresses
 
                 await checkout
-                  .updateOrderFormShipping(orderFormId, { address })
+                  .updateOrderFormShipping(orderFormId, {
+                    address,
+                    clearAddressIfPostalCodeNotFound: false,
+                  })
                   .catch((error) => {
                     logger.error({
                       message: 'setProfile.updateOrderFormShippingError',


### PR DESCRIPTION
Fix on the shipping data attachment payload passing the **_clearAddressIfPostalCodeNotFound_** flag to null.

**What problem is this solving?**

There was a problem with the US zip code addresses which was changing to null the street and neighborhood. 

**How should this be manually tested?**

[https://b2b--productusqa.myvtex.com/](https://b2b--productusqa.myvtex.com/)

Credentials: syed+tuesorgaoa1@bitcot.com  !Q2w#E4r%T6y&U

Add a product to the cart and proceed to checkout and finish it.
