### PR TITLE
[PERMISSION-25] Support telemarketing and join both users' permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for user impersonation via Telemarketing app
+
+### Changed
+
+- `checkUserPermission` will return a superset of the original user's and the impersonated user's permissions, if impersonation is active. If the original user has a role, that user's role will be returned. If not, the impersonated user's role will be returned
+
 ## [1.14.4] - 2022-03-21
 
 ### Changed
+
 - Reviewed README.md file
 
 ## [1.14.3] - 2022-03-17
+
 ### Changed
+
 - New version to re-deploy
+
 ## [1.14.2] - 2022-03-17
 
 ### Removed
+
 - Dependencies `search-segment-resolver` and `search-segment-graphql`
 
 ### Added
-- Addition information to the `impersonateUser` Mutation 
+
+- Addition information to the `impersonateUser` Mutation
 
 ## [1.14.1] - 2022-03-16
 

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-params */
 import type {
   InstanceOptions,
   RequestConfig,
@@ -43,7 +44,7 @@ export class Checkout extends JanusClient {
 
   private getChannelQueryString = () => {
     const { segment } = this.context as CustomIOContext
-    const channel = segment && segment.channel
+    const channel = segment?.channel
     const queryString = channel ? `?sc=${channel}` : ''
 
     return queryString
@@ -169,11 +170,9 @@ export class Checkout extends JanusClient {
     })
 
   public orderForm = (orderFormId?: string) => {
-    return this.post<OrderForm>(
-      this.routes.orderForm(orderFormId),
-      { expectedOrderFormSections: ['items'] },
-      { metric: 'checkout-orderForm' }
-    )
+    return this.get<OrderForm>(this.routes.orderForm(orderFormId), {
+      metric: 'checkout-orderForm',
+    })
   }
 
   public orderFormRaw = () => {

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -220,6 +220,60 @@ export const listUsers = async (
   }
 }
 
+const getRoleAndPermissionsByEmail = async ({
+  email,
+  module,
+  skipError = false,
+  ctx,
+}: {
+  email: string
+  module: string
+  skipError: boolean
+  ctx: Context
+}) => {
+  let ret = {
+    role: {
+      id: '',
+      name: '',
+      slug: '',
+    },
+    permissions: [],
+  }
+
+  if (!email) return ret
+
+  const userData: any = await getUserByEmail(null, { email }, ctx)
+
+  if (!userData.length && !skipError) {
+    throw new Error('User not found')
+  }
+
+  if (!userData.length) return ret
+
+  const userRole: any = await getRole(null, { id: userData[0].roleId }, ctx)
+
+  if (!userRole && !skipError) {
+    throw new Error('Role not found')
+  }
+
+  if (!userRole) return ret
+
+  const currentModule = userRole.features?.find((feature: any) => {
+    return feature.module === module
+  })
+
+  ret = {
+    role: {
+      id: userRole.id,
+      name: userRole.name,
+      slug: userRole.slug,
+    },
+    permissions: currentModule?.features || [],
+  }
+
+  return ret
+}
+
 export const checkUserPermission = async (
   _: any,
   params: any,
@@ -239,41 +293,52 @@ export const checkUserPermission = async (
     throw new Error('Sender not available, make sure the query is private')
   }
 
-  const user = sessionData?.namespaces?.authentication
+  const authEmail =
+    sessionData?.namespaces?.authentication?.storeUserEmail?.value
 
-  let ret = null
+  const profileEmail = sessionData?.namespaces?.profile?.email?.value
 
-  if (user?.storeUserEmail?.value && sender) {
-    const module = removeVersionFromAppId(sender)
+  let ret = {
+    role: {
+      id: '',
+      name: '',
+      slug: '',
+    },
+    permissions: [],
+  }
 
-    const userData: any = await getUserByEmail(
-      _,
-      { email: user.storeUserEmail.value },
-      ctx
-    )
+  if (!sender) return ret
 
-    if (!userData.length && !skipError) {
-      throw new Error('User not found')
-    }
+  const module = removeVersionFromAppId(sender)
 
-    if (userData.length) {
-      const userRole: any = await getRole(_, { id: userData[0].roleId }, ctx)
+  const authPermissions = await getRoleAndPermissionsByEmail({
+    email: authEmail,
+    module,
+    skipError: true,
+    ctx,
+  })
 
-      if (!userRole && !skipError) {
-        throw new Error('Role not found')
-      }
+  let profilePermissions = ret
 
-      if (userRole) {
-        const currentModule = userRole.features?.find((feature: any) => {
-          return feature.module === module
-        })
+  if (profileEmail && authEmail !== profileEmail) {
+    profilePermissions = await getRoleAndPermissionsByEmail({
+      email: profileEmail,
+      module,
+      skipError: true,
+      ctx,
+    })
+  }
 
-        ret = {
-          role: userRole,
-          permissions: currentModule?.features ?? [],
-        }
-      }
-    }
+  ret = {
+    role: authPermissions.role.id
+      ? authPermissions.role
+      : profilePermissions.role,
+    permissions: [
+      ...new Set([
+        ...authPermissions.permissions,
+        ...profilePermissions.permissions,
+      ]),
+    ],
   }
 
   return ret

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -231,6 +231,10 @@ const getRoleAndPermissionsByEmail = async ({
   skipError: boolean
   ctx: Context
 }) => {
+  const {
+    vtex: { logger },
+  } = ctx
+
   let ret = {
     role: {
       id: '',
@@ -245,6 +249,10 @@ const getRoleAndPermissionsByEmail = async ({
   const userData: any = await getUserByEmail(null, { email }, ctx)
 
   if (!userData.length && !skipError) {
+    logger.warn({
+      message: `getRoleAndPermissionsByEmail-userNotFound`,
+      email,
+    })
     throw new Error('User not found')
   }
 
@@ -253,6 +261,10 @@ const getRoleAndPermissionsByEmail = async ({
   const userRole: any = await getRole(null, { id: userData[0].roleId }, ctx)
 
   if (!userRole && !skipError) {
+    logger.warn({
+      message: `getRoleAndPermissionsByEmail-roleNotFound`,
+      roleId: userData[0].roleId,
+    })
     throw new Error('Role not found')
   }
 
@@ -281,15 +293,25 @@ export const checkUserPermission = async (
 ) => {
   await getAppSettings(null, null, ctx)
 
+  const {
+    vtex: { logger },
+  } = ctx
+
   const { sessionData, sender }: any = ctx.vtex
 
   const skipError = params?.skipError ?? false
 
   if (!sessionData?.namespaces && !skipError) {
+    logger.warn({
+      message: `checkUserPermission-userNotAuthenticated`,
+    })
     throw new Error('User not authenticated, make sure the query is private')
   }
 
   if (!sender && !skipError) {
+    logger.warn({
+      message: `checkUserPermission-senderNotFound`,
+    })
     throw new Error('Sender not available, make sure the query is private')
   }
 
@@ -347,11 +369,15 @@ export const checkUserPermission = async (
 export const checkImpersonation = async (_: any, __: any, ctx: Context) => {
   const {
     clients: { profileSystem },
+    vtex: { logger },
   } = ctx
 
   const { sessionData }: any = ctx.vtex
 
   if (!sessionData?.namespaces) {
+    logger.warn({
+      message: `checkImpersonation-userNotAuthenticated`,
+    })
     throw new Error('User not authenticated, make sure the query is private')
   }
 

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -57,6 +57,10 @@ const QUERIES = {
 export const resolvers = {
   Routes: {
     checkPermissions: async (ctx: Context) => {
+      const {
+        vtex: { logger },
+      } = ctx
+
       ctx.set('Content-Type', 'application/json')
       await getAppSettings(null, null, ctx)
 
@@ -65,10 +69,18 @@ export const resolvers = {
       let ret
 
       if (!params?.app) {
+        logger.warn({
+          message: `checkPermissions-appNotDefined`,
+          params,
+        })
         throw new Error('App not defined')
       }
 
       if (!params?.email) {
+        logger.warn({
+          message: `checkPermissions-emailNotDefined`,
+          params,
+        })
         throw new Error('Email not defined')
       }
 
@@ -79,6 +91,10 @@ export const resolvers = {
       )
 
       if (!userData.length) {
+        logger.warn({
+          message: `checkPermissions-userNotFound`,
+          email: params.email,
+        })
         throw new Error('User not found')
       }
 
@@ -90,6 +106,10 @@ export const resolvers = {
         )
 
         if (!userRole) {
+          logger.warn({
+            message: `checkPermissions-roleNotFound`,
+            roleId: userData[0].roleId,
+          })
           throw new Error('Role not found')
         }
 
@@ -232,6 +252,12 @@ export const resolvers = {
               organizationResponse?.data?.getOrganizationById?.status ===
               'inactive'
             ) {
+              logger.warn({
+                message: `setProfile-organizationInactive`,
+                organizationId: user.orgId,
+                organizationData:
+                  organizationResponse?.data?.getOrganizationById,
+              })
               throw new ForbiddenError('Organization is inactive')
             }
 

--- a/node/service.json
+++ b/node/service.json
@@ -1,8 +1,8 @@
 {
   "stack": "nodejs",
-  "memory": 1024,
-  "ttl": 300,
-  "timeout": 60,
+  "memory": 256,
+  "ttl": 60,
+  "timeout": 30,
   "cpu": {
     "type": "shared",
     "value": 5,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1492,7 +1492,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**

Previously this app did not support impersonation via the [telemarketing app](https://github.com/vtex-apps/telemarketing) but we had several requests to make the two systems work together.

This PR adds support for telemarketing impersonation. This solution relies on the `orderForm` to tell our app that a telemarketing impersonation session is active, by checking for a `userProfileId` and a `userType` of `callCenterOperator`. Finally, it checks if the email address in `orderForm.clientProfileData` is different from the authenticated user's email address. If all of this is true, the impersonated user's organization information will be loaded and applied to the session, the same as if our B2B impersonation feature was used.

This PR also adjusts the `checkUserPermission` query to account for the fact that if the original user is a call center operator, they may not have any B2B role or permissions of their own. Therefore, instead of only returning the original user's permissions, the app now tries to load both the original user's and the impersonated user's permissions, and then returns the joined array (after removing any duplicates). 

`checkUserPermissions` also returns the user's role information. For this, the app will return only the original user's role, unless the original user has no role, in which case the impersonated user's role will be returned. 

**How should this be manually tested?**

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com
and here: https://arthur--hermespardini.myvtex.com/

On `hermespardini`, first give yourself the Call Center Operator role by going to https://arthur--hermespardini.myvtex.com/admin/users

Then, in the storefront, use the impersonation header bar to impersonate sofia.diaz@vtex.com.br
In checkout, you should see her cost center's address:
Rua Trovador José Naegele 94
Piratininga - Niterói - RJ
24350-285
Brasil