### PR TITLE
[B2BORG-84] Add support for businessDocument, optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `businessDocument` field on user's cost center
+
+### Fixed
+
+- Don't await orderForm update promises in session hook to avoid timeouts
+- Check user impersonation status via session properties rather than orderForm
+- Adjust conditional in `checkImpersonation` query so that only data related to B2B impersonation solution is returned
+
 ## [1.15.0] - 2022-04-01
 
 ### Added

--- a/node/index.ts
+++ b/node/index.ts
@@ -8,13 +8,13 @@ import type {
   IOContext,
   SegmentData,
 } from '@vtex/api'
-import { Service, AuthType, LRUCache } from '@vtex/api'
+import { method, Service, AuthType, LRUCache } from '@vtex/api'
 
 import { schemaDirectives } from './directives'
 import { Clients } from './clients'
 import { resolvers } from './resolvers'
 
-const TIMEOUT_MS = 4000
+const TIMEOUT_MS = 5000
 
 const defaultClientOptions = {
   retries: 1,
@@ -74,5 +74,12 @@ export default new Service<Clients, RecorderState, ParamsContext>({
     },
     schemaDirectives,
   },
-  routes: resolvers.Routes,
+  routes: {
+    setProfile: method({
+      POST: resolvers.Routes.setProfile,
+    }),
+    checkPermissions: method({
+      GET: resolvers.Routes.checkPermissions,
+    }),
+  },
 })

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -383,10 +383,14 @@ export const checkImpersonation = async (_: any, __: any, ctx: Context) => {
 
   const profile = sessionData?.namespaces?.profile
   const sfp = sessionData?.namespaces['storefront-permissions']
+  const authEmail =
+    sessionData?.namespaces?.authentication?.storeUserEmail?.value
 
   let ret = null
 
   if (
+    authEmail &&
+    profile?.email?.value !== authEmail &&
     sfp?.storeUserId?.value &&
     profile?.id?.value &&
     sfp?.storeUserId?.value === profile?.id?.value

--- a/vtex.session/configuration.json
+++ b/vtex.session/configuration.json
@@ -3,6 +3,7 @@
     "input": {
       "authentication": ["storeUserEmail"],
       "checkout": ["orderFormId"],
+      "impersonate": ["storeUserEmail", "storeUserId"],
       "public": ["impersonate"]
     },
     "output": {


### PR DESCRIPTION
**What problem is this solving?**

Recently we updated `b2b-organizations-graphql` to allow a `businessDocument` to be assigned to a cost center. This PR updates `storefront-permissions` so that if the `businessDocument` field is present:
- it will be added to the user's orderForm profile data
- the `isCorporate` profile flag will be set to `true`
- the `corporateName` profile field will be set to the name of the user's organization

Additionally, this PR optimizes the `setProfile` function so that it will be less likely to time out when called by the VTEX session hub. The function no longer awaits the resolution of the orderForm update operations, for example. Also, rather than checking the orderForm to see if there is a telemarketing impersonation session currently active, it gets this information from the session hub request payload (`/vtex.session/configuration.json` has been modified to add the necessary fields).   

**How should this be manually tested?**

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com
The "Cost 123" cost center in the "Artur ORG" organization currently has a `businessDocument` set, so it can be used for testing.