### PR TITLE
[PERMISSION-23] Modify storefront permissions so that it has 2 separate mutations for adding vs updating users

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,11 @@ on:
       - chore/*
   pull_request:
     types: [opened, synchronize, reopened]
-    
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   sonarcloud:
     name: SonarCloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- create a new Mutation to add a single user
+- create a new Mutation to update a single user
+- optimize code / structure
+
+
 ## [1.16.0] - 2022-04-05
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -85,8 +85,6 @@ type Mutation {
     costId: ID
     clId: ID
     canImpersonate: Boolean = false
-    name: String!
-    email: String!
   ): MutationResponse @cacheControl(scope: PRIVATE)
 
   addUser(

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -77,6 +77,29 @@ type Mutation {
     email: String!
   ): MutationResponse @cacheControl(scope: PRIVATE)
 
+  updateUser(
+    id: ID
+    roleId: ID!
+    userId: ID
+    orgId: ID
+    costId: ID
+    clId: ID
+    canImpersonate: Boolean = false
+    name: String!
+    email: String!
+  ): MutationResponse @cacheControl(scope: PRIVATE)
+
+  addUser(
+    id: ID
+    roleId: ID!
+    userId: ID
+    orgId: ID
+    costId: ID
+    canImpersonate: Boolean = false
+    name: String!
+    email: String!
+  ): MutationResponse @cacheControl(scope: PRIVATE)
+
   impersonateUser(userId: ID): MutationResponse @cacheControl(scope: PRIVATE)
   deleteUser(id: ID!, userId: ID, email: String!): MutationResponse
     @cacheControl(scope: PRIVATE)

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "1.16.0",
   "dependencies": {
-    "@vtex/api": "6.45.10",
+    "@vtex/api": "6.45.11-beta",
     "co-body": "^6.0.0",
     "jsonwebtoken": "^8.5.0",
     "qs": "^6.9.4",
@@ -22,7 +22,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.10",
+    "@vtex/api": "6.45.11-beta",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -3,7 +3,155 @@ import { currentSchema } from '../../utils'
 
 const config: any = currentSchema('b2b_users')
 
-export const saveUser = async (_: any, params: any, ctx: Context) => {
+const createPermission = async ({ lm, masterdata, vbase, params }: any) => {
+  const {
+    roleId,
+    canImpersonate,
+    name,
+    email,
+    userId,
+    clId,
+    orgId,
+    costId,
+    id,
+  } = params
+
+  let UserId = userId
+  let mdId = id
+
+  if (canImpersonate) {
+    await lm.saveUser(name, email).catch((err: any) => {
+      throw new Error(err)
+    })
+    const user = await lm.getUserIdByEmail(email)
+
+    UserId = user ?? userId
+  } else {
+    await lm.deleteUser(userId).catch((err: any) => {
+      throw new Error(err)
+    })
+  }
+
+  // check if new user's email already exists in storefront-permissions MD
+  if (!mdId) {
+    mdId = await masterdata
+      .searchDocuments({
+        dataEntity: config.name,
+        fields: ['id'],
+        pagination: { page: 1, pageSize: 90 },
+        schema: config.version,
+        where: `email=${email}`,
+      })
+      .then((r: any) => {
+        return r?.length ? r[0].id : null
+      })
+      .catch(() => {
+        return null
+      })
+  }
+
+  const ret = await masterdata
+    .createOrUpdateEntireDocument({
+      dataEntity: config.name,
+      fields: {
+        canImpersonate,
+        clId,
+        costId,
+        email,
+        name,
+        orgId,
+        roleId,
+        userId: UserId,
+      },
+      id: mdId,
+      schema: config.version,
+    })
+    .then((r: any) => {
+      return r
+    })
+    .catch((err: any) => {
+      if (err.response.status < 400) {
+        return {
+          DocumentId: id,
+        }
+      }
+
+      throw err
+    })
+
+  if (ret.DocumentId) {
+    await vbase.saveJSON('b2b_users', email, {
+      canImpersonate,
+      clId,
+      costId,
+      email,
+      id: ret.DocumentId,
+      name,
+      orgId,
+      roleId,
+      userId,
+    })
+  }
+}
+
+export const addUser = async (_: any, params: any, ctx: Context) => {
+  const {
+    clients: { masterdata, lm, vbase },
+    vtex: { logger },
+  } = ctx
+
+  try {
+    const newUser = await masterdata
+      .createDocument({
+        dataEntity: 'CL',
+        fields: {
+          email: params.email,
+          firstName: params.name,
+        },
+      })
+      .then((r: any) => {
+        return r
+      })
+      .catch((err: any) => {
+        if (err.response?.data?.Message === 'duplicated entry') {
+          return masterdata
+            .searchDocuments({
+              dataEntity: 'CL',
+              fields: ['id'],
+              pagination: {
+                page: 1,
+                pageSize: 1,
+              },
+              where: `email=${params.email}`,
+            })
+            .then((res: any) => {
+              return { DocumentId: res[0].id }
+            })
+        }
+
+        logger.error(err)
+        throw err
+      })
+
+    const cId = newUser.DocumentId
+
+    await createPermission({
+      lm,
+      masterdata,
+      params: {
+        ...params,
+        cId,
+      },
+      vbase,
+    })
+
+    return { status: 'success', message: '', id: cId }
+  } catch (err) {
+    return { status: 'error', message: err }
+  }
+}
+
+export const updateUser = async (_: any, params: any, ctx: Context) => {
   const {
     clients: { masterdata, lm, vbase },
     vtex: { logger },
@@ -12,132 +160,26 @@ export const saveUser = async (_: any, params: any, ctx: Context) => {
   try {
     // check if new user already exists in CL and create profile if not
     if (!params.clId) {
-      const newUser = await masterdata
-        .createDocument({
-          dataEntity: 'CL',
-          fields: {
-            firstName: params.name,
-            email: params.email,
-          },
-        })
-        .then((r: any) => {
-          return r
-        })
-        .catch((err: any) => {
-          if (err.response?.data?.Message === 'duplicated entry') {
-            return masterdata
-              .searchDocuments({
-                dataEntity: 'CL',
-                fields: ['id'],
-                where: `email=${params.email}`,
-                pagination: {
-                  page: 1,
-                  pageSize: 1,
-                },
-              })
-              .then((res: any) => {
-                return { DocumentId: res[0].id }
-              })
-          }
+      const { id: cId } = (await addUser(_, params, ctx)) as {
+        status: string
+        message: string
+        id: string
+      }
 
-          logger.error(err)
-          throw err
-        })
-
-      params.clId = newUser.DocumentId
+      params.cId = cId
     }
 
-    const {
-      roleId,
-      canImpersonate,
-      name,
-      email,
-      userId,
-      clId,
-      orgId,
-      costId,
-      id,
-    } = params
+    await createPermission({
+      lm,
+      masterdata,
+      params,
+      vbase,
+    })
 
-    let UserId = userId
-    let mdId = id
-
-    if (canImpersonate) {
-      await lm.saveUser(name, email).catch((err) => {
-        throw new Error(err)
-      })
-      const user = await lm.getUserIdByEmail(email)
-
-      UserId = user ?? userId
-    } else {
-      await lm.deleteUser(userId).catch((err) => {
-        throw new Error(err)
-      })
-    }
-
-    // check if new user's email already exists in storefront-permissions MD
-    if (!mdId) {
-      mdId = await masterdata
-        .searchDocuments({
-          dataEntity: config.name,
-          fields: ['id'],
-          schema: config.version,
-          pagination: { page: 1, pageSize: 90 },
-          where: `email=${email}`,
-        })
-        .then((r: any) => {
-          return r?.length ? r[0].id : null
-        })
-        .catch(() => {
-          return null
-        })
-    }
-
-    const ret = await masterdata
-      .createOrUpdateEntireDocument({
-        dataEntity: config.name,
-        fields: {
-          roleId,
-          userId: UserId,
-          clId,
-          orgId,
-          costId,
-          canImpersonate,
-          name,
-          email,
-        },
-        id: mdId,
-        schema: config.version,
-      })
-      .then((r: any) => {
-        return r
-      })
-      .catch((err) => {
-        if (err.response.status < 400) {
-          return {
-            DocumentId: id,
-          }
-        }
-
-        throw err
-      })
-
-    if (ret.DocumentId) {
-      await vbase.saveJSON('b2b_users', email, {
-        id: ret.DocumentId,
-        roleId,
-        userId,
-        clId,
-        orgId,
-        costId,
-        canImpersonate,
-        name,
-        email,
-      })
-    }
-
-    return { status: 'success', message: '', id: ret.DocumentId }
+    return { status: 'success', message: '', id: params.clId }
   } catch (e) {
+    logger.error({ message: 'Error saving user', error: e })
+
     return { status: 'error', message: e }
   }
 }
@@ -229,4 +271,18 @@ export const impersonateUser = async (_: any, params: any, ctx: Context) => {
   } catch (e) {
     return { status: 'error', message: e }
   }
+}
+
+/**
+ *
+ * Persist the user in the database
+ *
+ * @deprecated
+ *
+ * @param _
+ * @param params
+ * @param ctx
+ */
+export const saveUser = async (_: any, params: any, ctx: Context) => {
+  return updateUser(_, params, ctx)
 }

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -1,0 +1,355 @@
+import { ForbiddenError } from '@vtex/api'
+import { json } from 'co-body'
+
+import { getRole } from '../Queries/Roles'
+import { getAppSettings, getSessionWatcher } from '../Queries/Settings'
+import { getUserByEmail, getUserById } from '../Queries/Users'
+
+const QUERIES = {
+  getCostCenterById: `query Costcenter($id: ID!) {
+    getCostCenterById(id: $id) {
+      paymentTerms {
+        id
+        name
+      }
+      addresses {
+        addressId
+        addressType
+        addressQuery
+        postalCode
+        country
+        receiverName
+        city
+        state
+        street
+        number
+        complement
+        neighborhood
+        geoCoordinates
+        reference
+      }
+      businessDocument
+    }
+  }`,
+  getOrganizationById: `query Organization($id: ID!){
+    getOrganizationById(id: $id) @context(provider: "vtex.b2b-organizations-graphql"){
+      name
+      status
+      priceTables
+      collections {
+        id
+      }
+    }
+  }`,
+}
+
+export const checkPermissions = async (ctx: Context) => {
+  const {
+    vtex: { logger },
+  } = ctx
+
+  ctx.set('Content-Type', 'application/json')
+  await getAppSettings(null, null, ctx)
+
+  const params: any = await json(ctx.req)
+
+  let ret
+
+  if (!params?.app) {
+    logger.warn({
+      message: `checkPermissions-appNotDefined`,
+      params,
+    })
+    throw new Error('App not defined')
+  }
+
+  if (!params?.email) {
+    logger.warn({
+      message: `checkPermissions-emailNotDefined`,
+      params,
+    })
+    throw new Error('Email not defined')
+  }
+
+  const userData: any = await getUserByEmail(null, { email: params.email }, ctx)
+
+  if (!userData.length) {
+    logger.warn({
+      email: params.email,
+      message: `checkPermissions-userNotFound`,
+    })
+    throw new Error('User not found')
+  }
+
+  if (userData.length) {
+    const userRole: any = await getRole(null, { id: userData[0].roleId }, ctx)
+
+    if (!userRole) {
+      logger.warn({
+        message: `checkPermissions-roleNotFound`,
+        roleId: userData[0].roleId,
+      })
+      throw new Error('Role not found')
+    }
+
+    if (userRole) {
+      const currentModule = userRole.features.find((feature: any) => {
+        return feature.module === params.app
+      })
+
+      ret = {
+        permissions: currentModule?.features ?? [],
+        role: userRole,
+      }
+    }
+  }
+
+  ctx.response.body = ret
+  ctx.response.status = 200
+}
+
+export const setProfile = async (ctx: Context) => {
+  const {
+    clients: { graphqlServer, checkout, profileSystem },
+    req,
+    vtex: { logger },
+  } = ctx
+
+  const res = {
+    public: {
+      facets: {
+        value: '',
+      },
+    },
+    'storefront-permissions': {
+      costcenter: {
+        value: '',
+      },
+      organization: {
+        value: '',
+      },
+      priceTables: {
+        value: '',
+      },
+      storeUserEmail: {
+        value: '',
+      },
+      storeUserId: {
+        value: '',
+      },
+    },
+  }
+
+  ctx.set('Content-Type', 'application/json')
+  ctx.set('Cache-Control', 'no-cache, no-store')
+
+  const isWatchActive = await getSessionWatcher(null, null, ctx)
+
+  if (isWatchActive) {
+    const promises = [] as Array<Promise<any>>
+    const body: any = await json(req)
+
+    const b2bImpersonate = body?.public?.impersonate?.value ?? null
+
+    const telemarketingImpersonate =
+      body?.impersonate?.storeUserId?.value ?? null
+
+    let email = body?.authentication?.storeUserEmail?.value ?? null
+    const orderFormId = body?.checkout?.orderFormId?.value ?? null
+    let businessName = null
+    let businessDocument = null
+
+    if (b2bImpersonate) {
+      const profile: any = await profileSystem
+        .getProfileInfo(b2bImpersonate)
+        .catch((error) => {
+          logger.error({ message: 'setProfile.getProfileInfoError', error })
+        })
+
+      if (profile) {
+        res['storefront-permissions'].storeUserId.value = profile.userId
+        res['storefront-permissions'].storeUserEmail.value = profile.email
+        email = profile.email
+      }
+    } else if (telemarketingImpersonate) {
+      const telemarketingEmail =
+        body?.impersonate?.storeUserEmail?.value ?? null
+
+      res['storefront-permissions'].storeUserId.value = telemarketingImpersonate
+      res['storefront-permissions'].storeUserEmail.value = telemarketingEmail
+      email = telemarketingEmail
+    }
+
+    if (email) {
+      const [user]: any = await getUserByEmail(null, { email }, ctx).catch(
+        (error) => {
+          logger.warn({ message: 'setProfile.getUserByEmailError', error })
+        }
+      )
+
+      if (user?.orgId) {
+        res['storefront-permissions'].organization.value = user.orgId
+
+        const organizationResponse: any = await graphqlServer
+          .query(
+            QUERIES.getOrganizationById,
+            { id: user.orgId },
+            {
+              persistedQuery: {
+                provider: 'vtex.b2b-organizations-graphql@0.x',
+                sender: 'vtex.storefront-permissions@1.x',
+              },
+            }
+          )
+          .catch((error) => {
+            logger.error({
+              error,
+              message: 'setProfile.graphqlGetOrganizationById',
+            })
+          })
+
+        // prevent login if org is inactive
+        if (
+          organizationResponse?.data?.getOrganizationById?.status === 'inactive'
+        ) {
+          logger.warn({
+            message: `setProfile-organizationInactive`,
+            organizationData: organizationResponse?.data?.getOrganizationById,
+            organizationId: user.orgId,
+          })
+          throw new ForbiddenError('Organization is inactive')
+        }
+
+        if (organizationResponse?.data?.getOrganizationById?.name) {
+          businessName = organizationResponse?.data?.getOrganizationById?.name
+        }
+
+        if (
+          organizationResponse?.data?.getOrganizationById?.priceTables?.length
+        ) {
+          res[
+            'storefront-permissions'
+          ].priceTables.value = `${organizationResponse.data.getOrganizationById.priceTables.join(
+            ';'
+          )}`
+        }
+
+        if (
+          organizationResponse?.data?.getOrganizationById?.collections?.length
+        ) {
+          const collections =
+            organizationResponse.data.getOrganizationById.collections.map(
+              (collection: any) => `productClusterIds=${collection.id}`
+            )
+
+          res.public.facets.value = `${collections.join(';')}`
+        }
+
+        if (orderFormId) {
+          promises.push(
+            checkout
+              .updateOrderFormMarketingData(orderFormId, {
+                attachmentId: 'marketingData',
+                utmCampaign: user?.orgId,
+                utmMedium: user?.costId,
+              })
+              .catch((error) => {
+                logger.error({
+                  message: 'setProfile.updateOrderFormMarketingDataError',
+                  error,
+                })
+              })
+          )
+        }
+
+        if (user?.costId) {
+          res['storefront-permissions'].costcenter.value = user.costId
+          const costCenterResponse: any = await graphqlServer
+            .query(
+              QUERIES.getCostCenterById,
+              { id: user.costId },
+              {
+                persistedQuery: {
+                  provider: 'vtex.b2b-organizations-graphql@0.x',
+                  sender: 'vtex.storefront-permissions@1.x',
+                },
+              }
+            )
+            .catch((error) => {
+              logger.error({
+                error,
+                message: 'setProfile.graphqlGetCostCenterById',
+              })
+            })
+
+          if (costCenterResponse?.data?.getCostCenterById?.businessDocument) {
+            businessDocument =
+              costCenterResponse.data.getCostCenterById.businessDocument
+          }
+
+          if (
+            costCenterResponse?.data?.getCostCenterById?.addresses?.length &&
+            orderFormId
+          ) {
+            const [address] =
+              costCenterResponse.data.getCostCenterById.addresses
+
+            promises.push(
+              checkout
+                .updateOrderFormShipping(orderFormId, {
+                  address,
+                  clearAddressIfPostalCodeNotFound: false,
+                })
+                .catch((error) => {
+                  logger.error({
+                    error,
+                    message: 'setProfile.updateOrderFormShippingError',
+                  })
+                })
+            )
+          }
+        }
+
+        if (user?.clId) {
+          const clUser = await getUserById(null, { id: user.clId }, ctx).catch(
+            (error) => {
+              logger.error({ message: 'setProfile.getUserByIdError', error })
+            }
+          )
+
+          if (clUser && orderFormId) {
+            if (clUser.isCorporate === null) clUser.isCorporate = false
+
+            if (businessName && businessDocument) {
+              clUser.isCorporate = true
+              clUser.corporateName = businessName
+              clUser.corporateDocument = businessDocument
+            }
+
+            promises.push(
+              checkout
+                .updateOrderFormProfile(orderFormId, clUser)
+                .catch((error) => {
+                  logger.error({
+                    error,
+                    message: 'setProfile.updateOrderFormProfileError',
+                  })
+                })
+            )
+          }
+        }
+      }
+    }
+
+    // Don't await promises, to avoid session timeout
+    Promise.all(promises).catch((error) => {
+      logger.error({
+        error,
+        message: 'setProfile.updateOrderFormProfileError',
+      })
+    })
+  }
+
+  ctx.response.body = res
+  ctx.response.status = 200
+}

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -43,231 +43,162 @@ const QUERIES = {
   }`,
 }
 
-export const checkPermissions = async (ctx: Context) => {
-  const {
-    vtex: { logger },
-  } = ctx
+export const Routes = {
+  checkPermissions: async (ctx: Context) => {
+    const {
+      vtex: { logger },
+    } = ctx
 
-  ctx.set('Content-Type', 'application/json')
-  await getAppSettings(null, null, ctx)
+    ctx.set('Content-Type', 'application/json')
+    await getAppSettings(null, null, ctx)
 
-  const params: any = await json(ctx.req)
+    const params: any = await json(ctx.req)
 
-  let ret
+    let ret
 
-  if (!params?.app) {
-    logger.warn({
-      message: `checkPermissions-appNotDefined`,
-      params,
-    })
-    throw new Error('App not defined')
-  }
-
-  if (!params?.email) {
-    logger.warn({
-      message: `checkPermissions-emailNotDefined`,
-      params,
-    })
-    throw new Error('Email not defined')
-  }
-
-  const userData: any = await getUserByEmail(null, { email: params.email }, ctx)
-
-  if (!userData.length) {
-    logger.warn({
-      email: params.email,
-      message: `checkPermissions-userNotFound`,
-    })
-    throw new Error('User not found')
-  }
-
-  if (userData.length) {
-    const userRole: any = await getRole(null, { id: userData[0].roleId }, ctx)
-
-    if (!userRole) {
+    if (!params?.app) {
       logger.warn({
-        message: `checkPermissions-roleNotFound`,
-        roleId: userData[0].roleId,
+        message: `checkPermissions-appNotDefined`,
+        params,
       })
-      throw new Error('Role not found')
+      throw new Error('App not defined')
     }
 
-    if (userRole) {
-      const currentModule = userRole.features.find((feature: any) => {
-        return feature.module === params.app
+    if (!params?.email) {
+      logger.warn({
+        message: `checkPermissions-emailNotDefined`,
+        params,
       })
+      throw new Error('Email not defined')
+    }
 
-      ret = {
-        permissions: currentModule?.features ?? [],
-        role: userRole,
+    const userData: any = await getUserByEmail(
+      null,
+      { email: params.email },
+      ctx
+    )
+
+    if (!userData.length) {
+      logger.warn({
+        email: params.email,
+        message: `checkPermissions-userNotFound`,
+      })
+      throw new Error('User not found')
+    }
+
+    if (userData.length) {
+      const userRole: any = await getRole(null, { id: userData[0].roleId }, ctx)
+
+      if (!userRole) {
+        logger.warn({
+          message: `checkPermissions-roleNotFound`,
+          roleId: userData[0].roleId,
+        })
+        throw new Error('Role not found')
       }
-    }
-  }
 
-  ctx.response.body = ret
-  ctx.response.status = 200
-}
-
-export const setProfile = async (ctx: Context) => {
-  const {
-    clients: { graphqlServer, checkout, profileSystem },
-    req,
-    vtex: { logger },
-  } = ctx
-
-  const res = {
-    public: {
-      facets: {
-        value: '',
-      },
-    },
-    'storefront-permissions': {
-      costcenter: {
-        value: '',
-      },
-      organization: {
-        value: '',
-      },
-      priceTables: {
-        value: '',
-      },
-      storeUserEmail: {
-        value: '',
-      },
-      storeUserId: {
-        value: '',
-      },
-    },
-  }
-
-  ctx.set('Content-Type', 'application/json')
-  ctx.set('Cache-Control', 'no-cache, no-store')
-
-  const isWatchActive = await getSessionWatcher(null, null, ctx)
-
-  if (isWatchActive) {
-    const promises = [] as Array<Promise<any>>
-    const body: any = await json(req)
-
-    const b2bImpersonate = body?.public?.impersonate?.value ?? null
-
-    const telemarketingImpersonate =
-      body?.impersonate?.storeUserId?.value ?? null
-
-    let email = body?.authentication?.storeUserEmail?.value ?? null
-    const orderFormId = body?.checkout?.orderFormId?.value ?? null
-    let businessName = null
-    let businessDocument = null
-
-    if (b2bImpersonate) {
-      const profile: any = await profileSystem
-        .getProfileInfo(b2bImpersonate)
-        .catch((error) => {
-          logger.error({ message: 'setProfile.getProfileInfoError', error })
+      if (userRole) {
+        const currentModule = userRole.features.find((feature: any) => {
+          return feature.module === params.app
         })
 
-      if (profile) {
-        res['storefront-permissions'].storeUserId.value = profile.userId
-        res['storefront-permissions'].storeUserEmail.value = profile.email
-        email = profile.email
+        ret = {
+          permissions: currentModule?.features ?? [],
+          role: userRole,
+        }
       }
-    } else if (telemarketingImpersonate) {
-      const telemarketingEmail =
-        body?.impersonate?.storeUserEmail?.value ?? null
-
-      res['storefront-permissions'].storeUserId.value = telemarketingImpersonate
-      res['storefront-permissions'].storeUserEmail.value = telemarketingEmail
-      email = telemarketingEmail
     }
 
-    if (email) {
-      const [user]: any = await getUserByEmail(null, { email }, ctx).catch(
-        (error) => {
-          logger.warn({ message: 'setProfile.getUserByEmailError', error })
-        }
-      )
+    ctx.response.body = ret
+    ctx.response.status = 200
+  },
+  setProfile: async (ctx: Context) => {
+    const {
+      clients: { graphqlServer, checkout, profileSystem },
+      req,
+      vtex: { logger },
+    } = ctx
 
-      if (user?.orgId) {
-        res['storefront-permissions'].organization.value = user.orgId
+    const res = {
+      public: {
+        facets: {
+          value: '',
+        },
+      },
+      'storefront-permissions': {
+        costcenter: {
+          value: '',
+        },
+        organization: {
+          value: '',
+        },
+        priceTables: {
+          value: '',
+        },
+        storeUserEmail: {
+          value: '',
+        },
+        storeUserId: {
+          value: '',
+        },
+      },
+    }
 
-        const organizationResponse: any = await graphqlServer
-          .query(
-            QUERIES.getOrganizationById,
-            { id: user.orgId },
-            {
-              persistedQuery: {
-                provider: 'vtex.b2b-organizations-graphql@0.x',
-                sender: 'vtex.storefront-permissions@1.x',
-              },
-            }
-          )
+    ctx.set('Content-Type', 'application/json')
+    ctx.set('Cache-Control', 'no-cache, no-store')
+
+    const isWatchActive = await getSessionWatcher(null, null, ctx)
+
+    if (isWatchActive) {
+      const promises = [] as Array<Promise<any>>
+      const body: any = await json(req)
+
+      const b2bImpersonate = body?.public?.impersonate?.value ?? null
+
+      const telemarketingImpersonate =
+        body?.impersonate?.storeUserId?.value ?? null
+
+      let email = body?.authentication?.storeUserEmail?.value ?? null
+      const orderFormId = body?.checkout?.orderFormId?.value ?? null
+      let businessName = null
+      let businessDocument = null
+
+      if (b2bImpersonate) {
+        const profile: any = await profileSystem
+          .getProfileInfo(b2bImpersonate)
           .catch((error) => {
-            logger.error({
-              error,
-              message: 'setProfile.graphqlGetOrganizationById',
-            })
+            logger.error({ message: 'setProfile.getProfileInfoError', error })
           })
 
-        // prevent login if org is inactive
-        if (
-          organizationResponse?.data?.getOrganizationById?.status === 'inactive'
-        ) {
-          logger.warn({
-            message: `setProfile-organizationInactive`,
-            organizationData: organizationResponse?.data?.getOrganizationById,
-            organizationId: user.orgId,
-          })
-          throw new ForbiddenError('Organization is inactive')
+        if (profile) {
+          res['storefront-permissions'].storeUserId.value = profile.userId
+          res['storefront-permissions'].storeUserEmail.value = profile.email
+          email = profile.email
         }
+      } else if (telemarketingImpersonate) {
+        const telemarketingEmail =
+          body?.impersonate?.storeUserEmail?.value ?? null
 
-        if (organizationResponse?.data?.getOrganizationById?.name) {
-          businessName = organizationResponse?.data?.getOrganizationById?.name
-        }
+        res['storefront-permissions'].storeUserId.value =
+          telemarketingImpersonate
+        res['storefront-permissions'].storeUserEmail.value = telemarketingEmail
+        email = telemarketingEmail
+      }
 
-        if (
-          organizationResponse?.data?.getOrganizationById?.priceTables?.length
-        ) {
-          res[
-            'storefront-permissions'
-          ].priceTables.value = `${organizationResponse.data.getOrganizationById.priceTables.join(
-            ';'
-          )}`
-        }
+      if (email) {
+        const [user]: any = await getUserByEmail(null, { email }, ctx).catch(
+          (error) => {
+            logger.warn({ message: 'setProfile.getUserByEmailError', error })
+          }
+        )
 
-        if (
-          organizationResponse?.data?.getOrganizationById?.collections?.length
-        ) {
-          const collections =
-            organizationResponse.data.getOrganizationById.collections.map(
-              (collection: any) => `productClusterIds=${collection.id}`
-            )
+        if (user?.orgId) {
+          res['storefront-permissions'].organization.value = user.orgId
 
-          res.public.facets.value = `${collections.join(';')}`
-        }
-
-        if (orderFormId) {
-          promises.push(
-            checkout
-              .updateOrderFormMarketingData(orderFormId, {
-                attachmentId: 'marketingData',
-                utmCampaign: user?.orgId,
-                utmMedium: user?.costId,
-              })
-              .catch((error) => {
-                logger.error({
-                  message: 'setProfile.updateOrderFormMarketingDataError',
-                  error,
-                })
-              })
-          )
-        }
-
-        if (user?.costId) {
-          res['storefront-permissions'].costcenter.value = user.costId
-          const costCenterResponse: any = await graphqlServer
+          const organizationResponse: any = await graphqlServer
             .query(
-              QUERIES.getCostCenterById,
-              { id: user.costId },
+              QUERIES.getOrganizationById,
+              { id: user.orgId },
               {
                 persistedQuery: {
                   provider: 'vtex.b2b-organizations-graphql@0.x',
@@ -278,78 +209,158 @@ export const setProfile = async (ctx: Context) => {
             .catch((error) => {
               logger.error({
                 error,
-                message: 'setProfile.graphqlGetCostCenterById',
+                message: 'setProfile.graphqlGetOrganizationById',
               })
             })
 
-          if (costCenterResponse?.data?.getCostCenterById?.businessDocument) {
-            businessDocument =
-              costCenterResponse.data.getCostCenterById.businessDocument
+          // prevent login if org is inactive
+          if (
+            organizationResponse?.data?.getOrganizationById?.status ===
+            'inactive'
+          ) {
+            logger.warn({
+              message: `setProfile-organizationInactive`,
+              organizationData: organizationResponse?.data?.getOrganizationById,
+              organizationId: user.orgId,
+            })
+            throw new ForbiddenError('Organization is inactive')
+          }
+
+          if (organizationResponse?.data?.getOrganizationById?.name) {
+            businessName = organizationResponse?.data?.getOrganizationById?.name
           }
 
           if (
-            costCenterResponse?.data?.getCostCenterById?.addresses?.length &&
-            orderFormId
+            organizationResponse?.data?.getOrganizationById?.priceTables?.length
           ) {
-            const [address] =
-              costCenterResponse.data.getCostCenterById.addresses
+            res[
+              'storefront-permissions'
+            ].priceTables.value = `${organizationResponse.data.getOrganizationById.priceTables.join(
+              ';'
+            )}`
+          }
 
+          if (
+            organizationResponse?.data?.getOrganizationById?.collections?.length
+          ) {
+            const collections =
+              organizationResponse.data.getOrganizationById.collections.map(
+                (collection: any) => `productClusterIds=${collection.id}`
+              )
+
+            res.public.facets.value = `${collections.join(';')}`
+          }
+
+          if (orderFormId) {
             promises.push(
               checkout
-                .updateOrderFormShipping(orderFormId, {
-                  address,
-                  clearAddressIfPostalCodeNotFound: false,
+                .updateOrderFormMarketingData(orderFormId, {
+                  attachmentId: 'marketingData',
+                  utmCampaign: user?.orgId,
+                  utmMedium: user?.costId,
                 })
                 .catch((error) => {
                   logger.error({
                     error,
-                    message: 'setProfile.updateOrderFormShippingError',
+                    message: 'setProfile.updateOrderFormMarketingDataError',
                   })
                 })
             )
           }
-        }
 
-        if (user?.clId) {
-          const clUser = await getUserById(null, { id: user.clId }, ctx).catch(
-            (error) => {
-              logger.error({ message: 'setProfile.getUserByIdError', error })
-            }
-          )
-
-          if (clUser && orderFormId) {
-            if (clUser.isCorporate === null) clUser.isCorporate = false
-
-            if (businessName && businessDocument) {
-              clUser.isCorporate = true
-              clUser.corporateName = businessName
-              clUser.corporateDocument = businessDocument
-            }
-
-            promises.push(
-              checkout
-                .updateOrderFormProfile(orderFormId, clUser)
-                .catch((error) => {
-                  logger.error({
-                    error,
-                    message: 'setProfile.updateOrderFormProfileError',
-                  })
+          if (user?.costId) {
+            res['storefront-permissions'].costcenter.value = user.costId
+            const costCenterResponse: any = await graphqlServer
+              .query(
+                QUERIES.getCostCenterById,
+                { id: user.costId },
+                {
+                  persistedQuery: {
+                    provider: 'vtex.b2b-organizations-graphql@0.x',
+                    sender: 'vtex.storefront-permissions@1.x',
+                  },
+                }
+              )
+              .catch((error) => {
+                logger.error({
+                  error,
+                  message: 'setProfile.graphqlGetCostCenterById',
                 })
-            )
+              })
+
+            if (costCenterResponse?.data?.getCostCenterById?.businessDocument) {
+              businessDocument =
+                costCenterResponse.data.getCostCenterById.businessDocument
+            }
+
+            if (
+              costCenterResponse?.data?.getCostCenterById?.addresses?.length &&
+              orderFormId
+            ) {
+              const [address] =
+                costCenterResponse.data.getCostCenterById.addresses
+
+              promises.push(
+                checkout
+                  .updateOrderFormShipping(orderFormId, {
+                    address,
+                    clearAddressIfPostalCodeNotFound: false,
+                  })
+                  .catch((error) => {
+                    logger.error({
+                      error,
+                      message: 'setProfile.updateOrderFormShippingError',
+                    })
+                  })
+              )
+            }
+          }
+
+          if (user?.clId) {
+            const clUser = await getUserById(
+              null,
+              { id: user.clId },
+              ctx
+            ).catch((error) => {
+              logger.error({ message: 'setProfile.getUserByIdError', error })
+            })
+
+            if (clUser && orderFormId) {
+              if (clUser.isCorporate === null) {
+                clUser.isCorporate = false
+              }
+
+              if (businessName && businessDocument) {
+                clUser.isCorporate = true
+                clUser.corporateName = businessName
+                clUser.corporateDocument = businessDocument
+              }
+
+              promises.push(
+                checkout
+                  .updateOrderFormProfile(orderFormId, clUser)
+                  .catch((error) => {
+                    logger.error({
+                      error,
+                      message: 'setProfile.updateOrderFormProfileError',
+                    })
+                  })
+              )
+            }
           }
         }
       }
+
+      // Don't await promises, to avoid session timeout
+      Promise.all(promises).catch((error) => {
+        logger.error({
+          error,
+          message: 'setProfile.updateOrderFormProfileError',
+        })
+      })
     }
 
-    // Don't await promises, to avoid session timeout
-    Promise.all(promises).catch((error) => {
-      logger.error({
-        error,
-        message: 'setProfile.updateOrderFormProfileError',
-      })
-    })
-  }
-
-  ctx.response.body = res
-  ctx.response.status = 200
+    ctx.response.body = res
+    ctx.response.status = 200
+  },
 }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -4,6 +4,7 @@
 import { deleteRole, saveRole } from './Mutations/Roles'
 import { sessionWatcher } from './Mutations/Settings'
 import {
+  addUser,
   deleteUser,
   impersonateUser,
   saveUser,
@@ -23,6 +24,7 @@ import { Routes } from './Routes'
 
 export const resolvers = {
   Mutation: {
+    addUser,
     deleteRole,
     deleteUser,
     impersonateUser,

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,410 +1,52 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { json } from 'co-body'
-import { ForbiddenError } from '@vtex/api'
 
 import { deleteRole, saveRole } from './Mutations/Roles'
-import { getRole, listRoles, hasUsers } from './Queries/Roles'
-import { deleteUser, saveUser, impersonateUser } from './Mutations/Users'
 import { sessionWatcher } from './Mutations/Settings'
+import {
+  deleteUser,
+  impersonateUser,
+  saveUser,
+  updateUser,
+} from './Mutations/Users'
 import { getFeaturesByModule, listFeatures } from './Queries/Features'
+import { getRole, hasUsers, listRoles } from './Queries/Roles'
 import { getAppSettings, getSessionWatcher } from './Queries/Settings'
 import {
+  checkImpersonation,
+  checkUserPermission,
   getUser,
   getUserByEmail,
   listUsers,
-  checkUserPermission,
-  checkImpersonation,
-  getUserById,
 } from './Queries/Users'
-
-const QUERIES = {
-  getOrganizationById: `query Organization($id: ID!){
-    getOrganizationById(id: $id) @context(provider: "vtex.b2b-organizations-graphql"){
-      name
-      status
-      priceTables
-      collections {
-        id
-      }
-    }
-  }`,
-  getCostCenterById: `query Costcenter($id: ID!) {
-    getCostCenterById(id: $id) {
-      paymentTerms {
-        id
-        name
-      }
-      addresses {
-        addressId
-        addressType
-        addressQuery
-        postalCode
-        country
-        receiverName
-        city
-        state
-        street
-        number
-        complement
-        neighborhood
-        geoCoordinates
-        reference
-      }
-      businessDocument
-    }
-  }`,
-}
+import { checkPermissions, setProfile } from './Routes'
 
 export const resolvers = {
-  Routes: {
-    checkPermissions: async (ctx: Context) => {
-      const {
-        vtex: { logger },
-      } = ctx
-
-      ctx.set('Content-Type', 'application/json')
-      await getAppSettings(null, null, ctx)
-
-      const params: any = await json(ctx.req)
-
-      let ret
-
-      if (!params?.app) {
-        logger.warn({
-          message: `checkPermissions-appNotDefined`,
-          params,
-        })
-        throw new Error('App not defined')
-      }
-
-      if (!params?.email) {
-        logger.warn({
-          message: `checkPermissions-emailNotDefined`,
-          params,
-        })
-        throw new Error('Email not defined')
-      }
-
-      const userData: any = await getUserByEmail(
-        null,
-        { email: params.email },
-        ctx
-      )
-
-      if (!userData.length) {
-        logger.warn({
-          message: `checkPermissions-userNotFound`,
-          email: params.email,
-        })
-        throw new Error('User not found')
-      }
-
-      if (userData.length) {
-        const userRole: any = await getRole(
-          null,
-          { id: userData[0].roleId },
-          ctx
-        )
-
-        if (!userRole) {
-          logger.warn({
-            message: `checkPermissions-roleNotFound`,
-            roleId: userData[0].roleId,
-          })
-          throw new Error('Role not found')
-        }
-
-        if (userRole) {
-          const currentModule = userRole.features.find((feature: any) => {
-            return feature.module === params.app
-          })
-
-          ret = {
-            role: userRole,
-            permissions: currentModule?.features ?? [],
-          }
-        }
-      }
-
-      ctx.response.body = ret
-
-      ctx.response.status = 200
-    },
-    setProfile: async (ctx: Context) => {
-      const {
-        clients: { graphqlServer, checkout, profileSystem },
-        req,
-        vtex: { logger },
-      } = ctx
-
-      const res = {
-        'storefront-permissions': {
-          organization: {
-            value: '',
-          },
-          costcenter: {
-            value: '',
-          },
-          priceTables: {
-            value: '',
-          },
-          storeUserId: {
-            value: '',
-          },
-          storeUserEmail: {
-            value: '',
-          },
-        },
-        public: {
-          facets: {
-            value: '',
-          },
-        },
-      }
-
-      ctx.set('Content-Type', 'application/json')
-      ctx.set('Cache-Control', 'no-cache, no-store')
-
-      const isWatchActive = await getSessionWatcher(null, null, ctx)
-
-      if (isWatchActive) {
-        const promises = [] as Array<Promise<any>>
-        const body: any = await json(req)
-
-        const b2bImpersonate = body?.public?.impersonate?.value ?? null
-
-        const telemarketingImpersonate =
-          body?.impersonate?.storeUserId?.value ?? null
-
-        let email = body?.authentication?.storeUserEmail?.value ?? null
-        const orderFormId = body?.checkout?.orderFormId?.value ?? null
-        let businessName = null
-        let businessDocument = null
-
-        if (b2bImpersonate) {
-          const profile: any = await profileSystem
-            .getProfileInfo(b2bImpersonate)
-            .catch((error) => {
-              logger.error({ message: 'setProfile.getProfileInfoError', error })
-            })
-
-          if (profile) {
-            res['storefront-permissions'].storeUserId.value = profile.userId
-            res['storefront-permissions'].storeUserEmail.value = profile.email
-            email = profile.email
-          }
-        } else if (telemarketingImpersonate) {
-          const telemarketingEmail =
-            body?.impersonate?.storeUserEmail?.value ?? null
-
-          res['storefront-permissions'].storeUserId.value =
-            telemarketingImpersonate
-          res['storefront-permissions'].storeUserEmail.value =
-            telemarketingEmail
-          email = telemarketingEmail
-        }
-
-        if (email) {
-          const [user]: any = await getUserByEmail(null, { email }, ctx).catch(
-            (error) => {
-              logger.warn({ message: 'setProfile.getUserByEmailError', error })
-            }
-          )
-
-          if (user?.orgId) {
-            res['storefront-permissions'].organization.value = user.orgId
-
-            const organizationResponse: any = await graphqlServer
-              .query(
-                QUERIES.getOrganizationById,
-                { id: user.orgId },
-                {
-                  persistedQuery: {
-                    provider: 'vtex.b2b-organizations-graphql@0.x',
-                    sender: 'vtex.storefront-permissions@1.x',
-                  },
-                }
-              )
-              .catch((error) => {
-                logger.error({
-                  message: 'setProfile.graphqlGetOrganizationById',
-                  error,
-                })
-              })
-
-            // prevent login if org is inactive
-            if (
-              organizationResponse?.data?.getOrganizationById?.status ===
-              'inactive'
-            ) {
-              logger.warn({
-                message: `setProfile-organizationInactive`,
-                organizationId: user.orgId,
-                organizationData:
-                  organizationResponse?.data?.getOrganizationById,
-              })
-              throw new ForbiddenError('Organization is inactive')
-            }
-
-            if (organizationResponse?.data?.getOrganizationById?.name) {
-              businessName =
-                organizationResponse?.data?.getOrganizationById?.name
-            }
-
-            if (
-              organizationResponse?.data?.getOrganizationById?.priceTables
-                ?.length
-            ) {
-              res[
-                'storefront-permissions'
-              ].priceTables.value = `${organizationResponse.data.getOrganizationById.priceTables.join(
-                ';'
-              )}`
-            }
-
-            if (
-              organizationResponse?.data?.getOrganizationById?.collections
-                ?.length
-            ) {
-              const collections =
-                organizationResponse.data.getOrganizationById.collections.map(
-                  (collection: any) => `productClusterIds=${collection.id}`
-                )
-
-              res.public.facets.value = `${collections.join(';')}`
-            }
-
-            if (orderFormId) {
-              promises.push(
-                checkout
-                  .updateOrderFormMarketingData(orderFormId, {
-                    attachmentId: 'marketingData',
-                    utmCampaign: user?.orgId,
-                    utmMedium: user?.costId,
-                  })
-                  .catch((error) => {
-                    logger.error({
-                      message: 'setProfile.updateOrderFormMarketingDataError',
-                      error,
-                    })
-                  })
-              )
-            }
-
-            if (user?.costId) {
-              res['storefront-permissions'].costcenter.value = user.costId
-              const costCenterResponse: any = await graphqlServer
-                .query(
-                  QUERIES.getCostCenterById,
-                  { id: user.costId },
-                  {
-                    persistedQuery: {
-                      provider: 'vtex.b2b-organizations-graphql@0.x',
-                      sender: 'vtex.storefront-permissions@1.x',
-                    },
-                  }
-                )
-                .catch((error) => {
-                  logger.error({
-                    message: 'setProfile.graphqlGetCostCenterById',
-                    error,
-                  })
-                })
-
-              if (
-                costCenterResponse?.data?.getCostCenterById?.businessDocument
-              ) {
-                businessDocument =
-                  costCenterResponse.data.getCostCenterById.businessDocument
-              }
-
-              if (
-                costCenterResponse?.data?.getCostCenterById?.addresses
-                  ?.length &&
-                orderFormId
-              ) {
-                const [address] =
-                  costCenterResponse.data.getCostCenterById.addresses
-
-                promises.push(
-                  checkout
-                    .updateOrderFormShipping(orderFormId, {
-                      address,
-                      clearAddressIfPostalCodeNotFound: false,
-                    })
-                    .catch((error) => {
-                      logger.error({
-                        message: 'setProfile.updateOrderFormShippingError',
-                        error,
-                      })
-                    })
-                )
-              }
-            }
-
-            if (user?.clId) {
-              const clUser = await getUserById(
-                null,
-                { id: user.clId },
-                ctx
-              ).catch((error) => {
-                logger.error({ message: 'setProfile.getUserByIdError', error })
-              })
-
-              if (clUser && orderFormId) {
-                if (clUser.isCorporate === null) clUser.isCorporate = false
-
-                if (businessName && businessDocument) {
-                  clUser.isCorporate = true
-                  clUser.corporateName = businessName
-                  clUser.corporateDocument = businessDocument
-                }
-
-                promises.push(
-                  checkout
-                    .updateOrderFormProfile(orderFormId, clUser)
-                    .catch((error) => {
-                      logger.error({
-                        message: 'setProfile.updateOrderFormProfileError',
-                        error,
-                      })
-                    })
-                )
-              }
-            }
-          }
-        }
-
-        // Don't await promises, to avoid session timeout
-        Promise.all(promises)
-      }
-
-      ctx.response.body = res
-
-      ctx.response.status = 200
-    },
-  },
   Mutation: {
     deleteRole,
-    saveRole,
     deleteUser,
-    saveUser,
     impersonateUser,
+    saveRole,
+    saveUser,
     sessionWatcher,
+    updateUser,
   },
   Query: {
-    getRole,
-    listRoles,
-    hasUsers,
+    checkImpersonation,
+    checkUserPermission,
+    getAppSettings,
     getFeaturesByModule,
-    listFeatures,
+    getRole,
+    getSessionWatcher,
     getUser,
     getUserByEmail,
+    hasUsers,
+    listFeatures,
+    listRoles,
     listUsers,
-    checkUserPermission,
-    checkImpersonation,
-    getAppSettings,
-    getSessionWatcher,
+  },
+  Routes: {
+    checkPermissions,
+    setProfile,
   },
 }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -19,7 +19,7 @@ import {
   getUserByEmail,
   listUsers,
 } from './Queries/Users'
-import { checkPermissions, setProfile } from './Routes'
+import { Routes } from './Routes'
 
 export const resolvers = {
   Mutation: {
@@ -45,8 +45,5 @@ export const resolvers = {
     listRoles,
     listUsers,
   },
-  Routes: {
-    checkPermissions,
-    setProfile,
-  },
+  Routes,
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -190,10 +190,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.45.10":
-  version "6.45.10"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.10.tgz#d338d05341e176593124fa171ea5710eee802e61"
-  integrity sha512-1OllEdBosqGbyGSvQtJzplmOISj2jalpgTDhRWlzhCdkGYbAg0Sm4doudKfZdvizu/6D1Dz4Uy2YncT6M3Vzng==
+"@vtex/api@6.45.11-beta":
+  version "6.45.11-beta"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.11-beta.tgz#edc51a2fdd3903f33caf7d63f198005f0d5a0c98"
+  integrity sha512-BFHMWU4SEFKXpbW3TWj0CI944p9ysmoCtB8ewpQlyRpUZFhPx2On/qFgBrD+Gqwt1yvysuKIAOfzfpjqKy88Gg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -214,7 +214,7 @@
     graphql "^14.5.8"
     graphql-tools "^4.0.6"
     graphql-upload "^8.1.0"
-    jaeger-client "^3.18.0"
+    jaeger-client "^3.19.0"
     js-base64 "^2.5.1"
     koa "^2.11.0"
     koa-compose "^4.1.0"
@@ -224,7 +224,7 @@
     mime-types "^2.1.12"
     opentracing "^0.14.4"
     p-limit "^2.2.0"
-    prom-client "^12.0.0"
+    prom-client "^14.0.1"
     qs "^6.5.1"
     querystring "^0.2.0"
     ramda "^0.26.0"
@@ -971,16 +971,16 @@ iterall@^1.1.3, iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
-jaeger-client@^3.18.0:
-  version "3.18.1"
-  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.18.1.tgz#a8c7a778244ba117f4fb8775eb6aa5508703564e"
-  integrity sha512-eZLM2U6rJvYo0XbzQYFeMYfp29gQix7SKlmDReorp9hJkUwXZtTyxW81AcKdmFCjLHO5tFysTX+394BnjEnUZg==
+jaeger-client@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/jaeger-client/-/jaeger-client-3.19.0.tgz#9b5bd818ebd24e818616ee0f5cffe1722a53ae6e"
+  integrity sha512-M0c7cKHmdyEUtjemnJyx/y9uX16XHocL46yQvyqDlPdvAcwPDbHrIbKjQdBqtiE4apQ/9dmr+ZLJYYPGnurgpw==
   dependencies:
     node-int64 "^0.4.0"
     opentracing "^0.14.4"
     thriftrw "^3.5.0"
-    uuid "^3.2.1"
-    xorshift "^0.2.0"
+    uuid "^8.3.2"
+    xorshift "^1.1.1"
 
 js-base64@^2.5.1:
   version "2.6.4"
@@ -1356,10 +1356,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+prom-client@^14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.0.1.tgz#bdd9583e02ec95429677c0e013712d42ef1f86a8"
+  integrity sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==
   dependencies:
     tdigest "^0.1.1"
 
@@ -1492,7 +1492,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -1687,10 +1687,15 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.3:
+uuid@^3.1.0, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1.1.2:
   version "1.1.2"
@@ -1722,10 +1727,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-xorshift@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-0.2.1.tgz#fcd82267e9351c13f0fb9c73307f25331d29c63a"
-  integrity sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo=
+xorshift@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-1.2.0.tgz#30a4cdd8e9f8d09d959ed2a88c42a09c660e8148"
+  integrity sha512-iYgNnGyeeJ4t6U11NpA/QiKy+PXn5Aa3Azg5qkwIFz1tBLllQrjjsk9yzD7IAK0naNU4JxdeDgqW9ov4u/hc4g==
 
 xss@^1.0.6:
   version "1.0.9"


### PR DESCRIPTION
**What problem is this solving?**

Currently, there is a single mutation for adding & editing B2B users. This is causing some unexpected issues.
The solution was to create 2 mutations separated in order to handle the actions carefully and avoid unexpected issues.

Also, I modified the routes structure, added logging errors, and removed unnecessary variable declarations.

**Workspace Graphql Playground:**
[https://b2borg--sandboxusdev.myvtex.com/admin/graphql-ide](https://b2borg--sandboxusdev.myvtex.com/admin/graphql-ide)

### Mutations

**Update User** 
```graphql
mutation ($id: ID $clId: ID! $userId: ID! $roleId: ID! $orgId: ID! $costId: ID! $canImpersonate: Boolean!) {
  updateUser (id:$id, clId: $clId, userId: $userId, roleId: $roleId, orgId: $orgId, costId: $costId, canImpersonate: $canImpersonate) {
    id
  }
}
```

#### Variables
```json
{
  "id": "5045efe4-8f6b-11ec-835d-0e43ea5f97c5",
  "clId": "87171494-7896-11ec-82ac-0e3ee09793d5",
  "userId": "c3ef51ae-1bca-4039-bddb-5ae1731933c8",
  "roleId": "f2a38526-f3bd-11eb-82ac-12fda6a1f41f",
  "orgId": "1574d7ea-1250-11ec-82ac-020154316047",
  "costId": "61cd16b4-7d60-11ec-82ac-0ac0af4028a1",
  "canImpersonate": false
}

```


**Add User** 
```graphql
mutation ($id: ID $userId: ID! $roleId: ID! $orgId: ID! $costId: ID! $name: String! $canImpersonate: Boolean! $email: String!) {
  addUser (id:$id, userId: $userId, roleId: $roleId, orgId: $orgId, costId: $costId, name: $name, canImpersonate: $canImpersonate, email: $email) {
    id
  }
}
```

#### Variables
```json
{
  "id": "5045efe4-8f6b-11ec-835d-0e43ea5f97c5",  
  "userId": "c3ef51ae-1bca-4039-bddb-5ae1731933c8",
  "roleId": "f2a38526-f3bd-11eb-82ac-12fda6a1f41f",
  "orgId": "1574d7ea-1250-11ec-82ac-020154316047",
  "costId": "61cd16b4-7d60-11ec-82ac-0ac0af4028a1",
  "name": "Foo",
  "email": "foo@bar.bar",
  "canImpersonate": false
}

```