### PR TITLE
[B2BORG-118] Add support for tradeName and phoneNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support for `tradeName` field on user's organization and `phoneNumber` field on user's cost center
+
 ## [1.21.1] - 2022-06-22
 
 ### Added
@@ -57,7 +61,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - create a new Mutation to add a single user
 - create a new Mutation to update a single user
 - optimize code / structure
-
 
 ## [1.16.0] - 2022-04-05
 

--- a/node/resolvers/Routes/utils/index.ts
+++ b/node/resolvers/Routes/utils/index.ts
@@ -1,0 +1,92 @@
+import { getUserById } from '../../Queries/Users'
+
+export const QUERIES = {
+  getCostCenterById: `query Costcenter($id: ID!) {
+      getCostCenterById(id: $id) {
+        paymentTerms {
+          id
+          name
+        }
+        addresses {
+          addressId
+          addressType
+          addressQuery
+          postalCode
+          country
+          receiverName
+          city
+          state
+          street
+          number
+          complement
+          neighborhood
+          geoCoordinates
+          reference
+        }
+        phoneNumber
+        businessDocument
+      }
+    }`,
+  getOrganizationById: `query Organization($id: ID!){
+      getOrganizationById(id: $id) @context(provider: "vtex.b2b-organizations-graphql"){
+        name
+        tradeName
+        status
+        priceTables
+        collections {
+          id
+        }
+      }
+    }`,
+}
+
+export const generateClUser = async ({
+  clId,
+  phoneNumber,
+  businessName,
+  businessDocument,
+  tradeName,
+  ctx,
+}: {
+  clId: string
+  phoneNumber: string | null
+  businessName: string | null
+  businessDocument: string | null
+  tradeName: string | null
+  ctx: Context
+}) => {
+  const {
+    vtex: { logger },
+  } = ctx
+
+  if (!clId) return null
+
+  const clUser = await getUserById(null, { id: clId }, ctx).catch((error) => {
+    logger.error({ message: 'setProfile.getUserByIdError', error })
+  })
+
+  if (!clUser) return null
+
+  if (clUser.isCorporate === null) {
+    clUser.isCorporate = false
+  }
+
+  if (phoneNumber) {
+    clUser.phone = phoneNumber
+  }
+
+  if (businessName && businessDocument) {
+    clUser.isCorporate = true
+    clUser.corporateName = businessName
+    clUser.corporateDocument = businessDocument
+    if (phoneNumber) {
+      clUser.corporatePhone = phoneNumber
+    }
+
+    if (tradeName) {
+      clUser.tradeName = tradeName
+    }
+  }
+
+  return clUser
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1492,7 +1492,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**

B2B Organizations and B2B Organizations GraphQL have already been updated to allow B2B users to define a `tradeName` for their organization and a `phoneNumber` for their cost centers. This PR updates Storefront Permissions to inject these values into the user's session, if present. Also, the `setProfile` function has been refactored to pass SonarCloud's cognitive complexity check.

**How should this be manually tested?**
Linked in https://b2bsuite--sandboxusdev.myvtex.com
Log in as a user in an organization that has a `tradeName` and/or in a cost center that has a `phoneNumber`, and then go to checkout. The specified values should be added into the relevant checkout fields.