### PR TITLE
[B2BORG-142] Hide for b2c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `getUserByEmail` query
+
 ## [1.22.1] - 2022-07-12
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -23,7 +23,7 @@ type Query {
   # User
   getUser(id: ID!): User @cacheControl(scope: PRIVATE)
   checkCustomerSchema: Boolean @cacheControl(scope: PRIVATE)
-  getUserByEmail(email: String!): User @cacheControl(scope: PRIVATE)
+  getUserByEmail(email: String!): [User] @cacheControl(scope: PRIVATE)
   listAllUsers: [User] @cacheControl(scope: PRIVATE, maxAge: SHORT)
 
   listUsers(organizationId: ID, costCenterId: ID, roleId: ID): [User]


### PR DESCRIPTION
**What problem is this solving?**

Previously, the `getUserByEmail` query will return null for all users. This PR fix the query and make sure it returns valid id for b2b users.

**How should this be manually tested?**
In the graphql-ide of [workspace](https://b2borg--sandboxusdev.myvtex.com/admin/graphql-ide), 
test
`query CheckPermissions($email: String!) {
  getUserByEmail(email: $email)
   {
    id
    roleId
    userId
    clId
    orgId
    costId
    canImpersonate
  }
}`
