### PR TITLE
[B2BORG-151] Change organization on users session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- As part of one-to-many feature, was added a mutation to set the current organization to the user
+
 ## [1.24.0] - 2022-09-12
 
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -60,8 +60,7 @@ type Query {
 
   getUsersByEmail(email: String!): [User] @cacheControl(scope: PRIVATE)
 
-  getActiveUserByEmail(email: String!, orgId: ID!): User
-    @cacheControl(scope: PRIVATE)
+  getActiveUserByEmail(email: String!): User @cacheControl(scope: PRIVATE)
 
   getOrganizationsByEmail(email: String!): [Organization]
     @cacheControl(scope: PRIVATE)
@@ -125,7 +124,7 @@ type Mutation {
     roleId: ID
   ): MutationResponse @checkAdminAccess @cacheControl(scope: PRIVATE)
 
-  setActiveUserByOrganization(userId: ID, orgId: ID!): MutationResponse
+  setActiveUserByOrganization(userId: ID): MutationResponse
     @checkUserAccess
     @cacheControl(scope: PRIVATE)
 
@@ -135,6 +134,10 @@ type Mutation {
 
   deleteUser(id: ID!, userId: ID, email: String!): MutationResponse
     @checkAdminAccess
+    @cacheControl(scope: PRIVATE)
+
+  setCurrentOrganization(orgId: ID!, costId: ID!): MutationResponse
+    @withSession
     @cacheControl(scope: PRIVATE)
 }
 

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -682,12 +682,9 @@ export const getActiveUserByEmail = async (
 
   try {
     const users = await getUsersByEmail(null, params, ctx)
-    const activeUser = users.find(
-      (user: any) => user.active && params.orgId === user.orgId
-    )
+    const activeUser = users.find((user: any) => user.active)
 
-    const userFound =
-      activeUser || users.find((user: any) => user.orgId === params.orgId)
+    const userFound = activeUser || users[0]
 
     if (!userFound) {
       logger.warn({

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -3,7 +3,7 @@ import { json } from 'co-body'
 
 import { getRole } from '../Queries/Roles'
 import { getAppSettings, getSessionWatcher } from '../Queries/Settings'
-import { getUserByEmail } from '../Queries/Users'
+import { getActiveUserByEmail, getUserByEmail } from '../Queries/Users'
 import { generateClUser, QUERIES } from './utils'
 
 export const Routes = {
@@ -169,11 +169,16 @@ export const Routes = {
       return
     }
 
-    const [user]: any = await getUserByEmail(null, { email }, ctx).catch(
+    const user = (await getActiveUserByEmail(null, { email }, ctx).catch(
       (error) => {
         logger.warn({ message: 'setProfile.getUserByEmailError', error })
       }
-    )
+    )) as {
+      orgId: string
+      costId: string
+      clId: string
+      id: string
+    }
 
     response['storefront-permissions'].userId.value = user?.id
 

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -11,6 +11,7 @@ import {
   impersonateUser,
   saveUser,
   setActiveUserByOrganization,
+  setCurrentOrganization,
   updateUser,
 } from './Mutations/Users'
 import { getFeaturesByModule, listFeatures } from './Queries/Features'
@@ -43,6 +44,7 @@ export const resolvers = {
     saveUser,
     sessionWatcher,
     setActiveUserByOrganization,
+    setCurrentOrganization,
     updateUser,
   },
   Query: {


### PR DESCRIPTION
**What problem is this solving?**
Hello guys ! 

In the B2B alliedempresas project we were waiting for the new feature 1ToMany, to allow 1 user to be related to several organizations that was released recently. 
we watched the demo last week done for the B2B electrolux project and we are already using the new admin UI to link the users to several organizations. 

However, besides allowing the 1ToMany, we also need to be able to change the organization set to the users session.

Currently when a user logs in, the session is set with one organization, and we need to be able to change it. On the demo you explained the feature to allow a dropdown to be able to select and change the organization is going to be developed.

**How should this be manually tested?**

Getting user data

```graphql
query {
  getOrganizationsByEmail(email: "artur.magalhaes+abc@vtex.com.br") {
    id
    orgId
    costId
  }
  getActiveUserByEmail(email: "artur.magalhaes+abc@vtex.com.br") {
    id
    orgId
    costId
  }
}
```

Mutation
```graphql
mutation {
  setCurrentOrganization(orgId: "e70361c5-0cee-11ed-835d-1233bbb9402d", costId: "e4cc014e-0cee-11ed-835d-0a71f2fa8c7d") {
    status
    message
  }
}

```