### PR TITLE
Issue with priceTables separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Join multiple priceTables with `,` instead of `;`
+
 ## [1.28.0] - 2022-10-26
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "storefront-permissions",
   "vendor": "vtex",
-  "version": "1.28.0",
+  "version": "1.28.1-beta.0",
   "title": "Storefront Permissions",
   "description": "Manage User's permissions on apps that relates to this app",
   "mustUpdateAt": "2022-08-28",

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -229,7 +229,7 @@ export const Routes = {
       response[
         'storefront-permissions'
       ].priceTables.value = `${organizationResponse.data.getOrganizationById.priceTables.join(
-        ';'
+        ','
       )}`
     }
 


### PR DESCRIPTION
**What problem is this solving?**
Error at the checkout when using multiple priceTables

[Splunk](https://vtex.splunkcloud.com/en-US/app/search/search?earliest=-3d%40d&latest=now&q=search%20index%3D*%20607ecb47-0f04-4761-bcc2-a8cb12dd0437&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1667393847.4669265_A2CD0FD4-C32E-4C6C-B6DB-20F8989F8580)


According to this [document](https://help.vtex.com/en/tutorial/configurar-price-tables-especificas-com-o-session)
> o create more than one, separate them by commas. For example: gold, silver