### PR TITLE
[PERMISSIONS-45]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- getOrganizationsByEmail is returning all users instead of only first 50 records
+
+
 ## [1.29.2] - 2022-11-28
 
 ### Fixed


### PR DESCRIPTION
## BugFix

fix: getOrganizationsByEmail is returning all users instead of only first 50 records

**What problem is this solving?**

There was a problem with getOrganizationsByEmail which was returning only the first 50 records.
Now is returning all records from MD correctly.

**How should this be manually tested?**

https://artur--alliedempresas.myvtex.com/admin/graphql-ide

```graphql
query {
  getOrganizationsByEmail(email:"tisopab528@turuma.com") {
    id
    clId
    orgId
    costId
    organizationName
    costCenterName
  }
}
```