### PR TITLE
Fix losing attachments after login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `setProfile` adding sku 1 to the cart to set sales channel when the cart is empty
+- `setProfile` losing item attachments after login
+
 ## [1.31.1] - 2023-02-24
 
 ### Fixed

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -185,11 +185,11 @@ export class Checkout extends JanusClient {
                     orderFormId,
                     attachment.name,
                     index
-                  )
-                ),
-                {
-                  content: attachment.content,
-                }
+                  ),
+                  {
+                    content: attachment.content,
+                  }
+                )
               )
             }
           )

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -7,6 +7,7 @@ import type {
 } from '@vtex/api'
 import { JanusClient } from '@vtex/api'
 import type { AxiosError } from 'axios'
+import { forEach } from 'ramda'
 
 import { checkoutCookieFormat, statusToError } from '../utils'
 
@@ -30,6 +31,12 @@ export class Checkout extends JanusClient {
         `${base}/orderForm/${orderFormId}/profile`,
       attachmentsData: (orderFormId: string, field: string) =>
         `${base}/orderForm/${orderFormId}/attachments/${field}`,
+      attachmentItem: (
+        orderFormId: string,
+        field: string,
+        index: string | number
+      ) =>
+        `${base}/orderForm/${orderFormId}/items/${index}/attachments/${field}`,
       assemblyOptions: (
         orderFormId: string,
         itemId: string | number,
@@ -146,12 +153,14 @@ export class Checkout extends JanusClient {
     orderFormId: string,
     salesChannel: any
   ) => {
-    const { items } = await this.get(this.routes.orderForm(orderFormId))
+    const of = await this.get(this.routes.orderForm(orderFormId))
 
-    if (items?.length) {
+    const { items, salesChannel: sc }: any = of
+
+    if (String(salesChannel) !== String(sc) && items?.length) {
       await this.clearCart(orderFormId)
 
-      return this.post(
+      await this.post(
         `${this.routes.orderForm(orderFormId)}/items?sc=${salesChannel}`,
         {
           orderItems: items.map((item: any) => ({
@@ -163,26 +172,53 @@ export class Checkout extends JanusClient {
           })),
         }
       )
+
+      // Check attachments
+      const attachmentPromise: any[] = []
+
+      items.forEach((item: { attachments: any[] }, index: string | number) => {
+        if (item.attachments?.length) {
+          item.attachments.forEach(
+            (attachment: { name: string; content: any }) => {
+              attachmentPromise.push(
+                this.post(
+                  this.routes.attachmentItem(
+                    orderFormId,
+                    attachment.name,
+                    index
+                  )
+                ),
+                {
+                  content: attachment.content,
+                }
+              )
+            }
+          )
+        }
+      })
+      if (attachmentPromise.length) {
+        await Promise.all(attachmentPromise)
+      }
     }
 
-    const response = await this.post(
-      `${this.routes.orderForm(orderFormId)}/items?sc=${salesChannel}`,
-      {
-        orderItems: [
-          {
-            id: '1',
-            index: 0,
-            price: 1,
-            quantity: 1,
-            seller: '1',
-          },
-        ],
-      }
-    )
+    // TODO: Change SC even without items. Suggestion, have a setting to define a "test sku"
+    // const response = await this.post(
+    //   `${this.routes.orderForm(orderFormId)}/items?sc=${salesChannel}`,
+    //   {
+    //     orderItems: [
+    //       {
+    //         id: '1',
+    //         index: 0,
+    //         price: 1,
+    //         quantity: 1,
+    //         seller: '1',
+    //       },
+    //     ],
+    //   }
+    // )
+    // await this.clearCart(orderFormId)
 
-    await this.clearCart(orderFormId)
-
-    return response
+    return of
   }
 
   public updateOrderFormClientPreferencesData = (

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -7,7 +7,6 @@ import type {
 } from '@vtex/api'
 import { JanusClient } from '@vtex/api'
 import type { AxiosError } from 'axios'
-import { forEach } from 'ramda'
 
 import { checkoutCookieFormat, statusToError } from '../utils'
 

--- a/node/clients/checkout.ts
+++ b/node/clients/checkout.ts
@@ -152,9 +152,9 @@ export class Checkout extends JanusClient {
     orderFormId: string,
     salesChannel: any
   ) => {
-    const of = await this.get(this.routes.orderForm(orderFormId))
+    const orderForm = await this.get(this.routes.orderForm(orderFormId))
 
-    const { items, salesChannel: sc }: any = of
+    const { items, salesChannel: sc }: any = orderForm
 
     if (String(salesChannel) !== String(sc) && items?.length) {
       await this.clearCart(orderFormId)
@@ -200,24 +200,7 @@ export class Checkout extends JanusClient {
       }
     }
 
-    // TODO: Change SC even without items. Suggestion, have a setting to define a "test sku"
-    // const response = await this.post(
-    //   `${this.routes.orderForm(orderFormId)}/items?sc=${salesChannel}`,
-    //   {
-    //     orderItems: [
-    //       {
-    //         id: '1',
-    //         index: 0,
-    //         price: 1,
-    //         quantity: 1,
-    //         seller: '1',
-    //       },
-    //     ],
-    //   }
-    // )
-    // await this.clearCart(orderFormId)
-
-    return of
+    return orderForm
   }
 
   public updateOrderFormClientPreferencesData = (

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { ForbiddenError } from '@vtex/api'
 import { json } from 'co-body'
 
@@ -519,8 +518,6 @@ export const Routes = {
 
     // Don't await promises, to avoid session timeout
     Promise.all(promises)
-
-    console.log('setProfile.output =>', { body, output: response })
 
     logger.info({
       'setProfile.body': JSON.stringify(body),

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ForbiddenError } from '@vtex/api'
 import { json } from 'co-body'
 
@@ -518,6 +519,13 @@ export const Routes = {
 
     // Don't await promises, to avoid session timeout
     Promise.all(promises)
+
+    console.log('setProfile.output =>', { body, output: response })
+
+    logger.info({
+      'setProfile.body': JSON.stringify(body),
+      'setProfile.output': JSON.stringify(response),
+    })
 
     ctx.response.body = response
     ctx.response.status = 200

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1417,7 +1417,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**

### Fixed
- `setProfile` adding sku 1 to the cart to set sales channel when the cart is empty
- `setProfile` losing item attachments after login

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

First test: Login with cart empty. It should stop showing the product not found or with no inventory toast message after login
Second test: With products in the cart with attachments, log out, and log back in. The attachment must stay the same

[https://setprofile--pierceqa.myvtex.com/](https://setprofile--pierceqa.myvtex.com/)
