### PR TITLE
Fix/regionalization behaviour

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,25 +10,23 @@
 
 When navigating a B2B store as a customer, it is common for a main user from an organization to have other people under their structure, each with their own information and access privileges.
 
-Within an organization, each user can have different roles, such as a professional buyer that places orders with budget limits from a predefined cost center or  a manager in charge of reviewing and approving orders. These roles can be associated with multiple permissions, depending on the actions this user needs to perform.
+Within an organization, each user can have different roles, such as a professional buyer that places orders with budget limits from a predefined cost center or a manager in charge of reviewing and approving orders. These roles can be associated with multiple permissions, depending on the actions this user needs to perform.
 
 The **Storefront Permissions** app stores a predefined set of roles and app permissions related to what B2B users can access and do in your storefront, making this information available for other integrated apps to check. This is useful for stores who want to set specific app permissions for users with different roles in an organization.
-
 
 ## Available storefront roles
 
 In the following table, you can see the available storefront roles, their key used for identification in the app’s code, and their description.
 
-| **Role** | **Key** | **Description** |
-|---|---|---|
-| Store Admin | `store-admin` | Store administrator, that is, a user who has access to the VTEX Admin. |
-| Sales Admin | `sales-admin` | Sales administrator user who can manage all sales users. |
-| Sales Manager | `sales-manager` | Sales manager user who can manage sales users in the same organization, as well as assist or impersonate buyers during navigation or purchase. |
-| Sales Representative | `sales-representative` | Sales representative user who can assist or impersonate buyers in the same cost center during navigation or purchase. |
-| Organization Admin | `customer-admin` | Main organization user who manages the organization information, as well as its members and cost centers. |
-| Organization Approver | `customer-approver` | Organization user who can take a saved cart or quote that was created by an **Organization Buyer** and use it to place an order. |
-| Organization Buyer | `customer-buyer` | Organization user who has the ability to add items to cart. If the **B2B Quotes** app is installed, they are also able to save their cart for future use or create a quote. |
-
+| **Role**              | **Key**                | **Description**                                                                                                                                                             |
+| --------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Store Admin           | `store-admin`          | Store administrator, that is, a user who has access to the VTEX Admin.                                                                                                      |
+| Sales Admin           | `sales-admin`          | Sales administrator user who can manage all sales users.                                                                                                                    |
+| Sales Manager         | `sales-manager`        | Sales manager user who can manage sales users in the same organization, as well as assist or impersonate buyers during navigation or purchase.                              |
+| Sales Representative  | `sales-representative` | Sales representative user who can assist or impersonate buyers in the same cost center during navigation or purchase.                                                       |
+| Organization Admin    | `customer-admin`       | Main organization user who manages the organization information, as well as its members and cost centers.                                                                   |
+| Organization Approver | `customer-approver`    | Organization user who can take a saved cart or quote that was created by an **Organization Buyer** and use it to place an order.                                            |
+| Organization Buyer    | `customer-buyer`       | Organization user who has the ability to add items to cart. If the **B2B Quotes** app is installed, they are also able to save their cart for future use or create a quote. |
 
 ## How it works
 
@@ -38,18 +36,15 @@ It also allows you to configure available permissions when developing your own a
 
 The **Storefront Permissions** app does not contain an interface – it operates “backstage”, storing the predefined roles and serving as a bridge to communicate with other apps in order to check user permissions. If you would like to manage roles and app permissions using the VTEX Admin interface, you must also install the [Storefront Permissions UI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-storefront-permissions-ui) app. As an optional feature, you can install the [Admin Customers](https://developers.vtex.com/vtex-developer-docs/docs/vtex-admin-customers) app for additional customer management capabilities.
 
-
 ## Before you start
 
 Make sure you have the [VTEX IO CLI (Command Line Interface)](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-install) installed in your machine.
 
 If you opt to develop your own app and [integrate](#advanced-app-integration-optional) it with **Storefront Permissions**, read our documentation on [Developing an app](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-developing-an-app).
 
-
 ## Installation
 
 You can install the app by running `vtex install vtex.storefront-permissions` in your terminal, using the [VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference).
-
 
 ## Advanced app integration [optional]
 
@@ -58,71 +53,87 @@ If you would like to develop your own app and integrate it with **Storefront Per
 1. Open your app’s repository.
 2. In the `manifest.json` file, add `vtex.storefront-permissions` under the `builders` property, as follows.
 
-    ```json
-    "builders": {
-    "vtex.storefront-permissions": "1.x"
-    }
-    ```
+   ```json
+   "builders": {
+   "vtex.storefront-permissions": "1.x"
+   }
+   ```
 
 3. In the root folder, create a new folder named `vtex.storefront-permissions`.
 4. In the `vtex.storefront-permissions` folder, create a `configuration.json` file. The content of this file should follow the format below. Keep in mind that you must replace the example information with the `name` of your app and its `features`.
 
-    ```json
-    {
-      "name": "My awesome app",
-      "features": [
-        {
-          "label": "View",
-          "value": "view-awesome-things",
-          "roles": ["store-admin","sales-admin","sales-manager","sales-representative","customer-admin","customer-approver","customer-buyer"]
-        },
-        {
-          "label": "Create",
-          "value": "create-awesome-things",
-          "roles": ["store-admin","sales-admin","sales-manager","sales-representative"]
-        },
-        {
-          "label": "Delete",
-          "value": "delete-awesome-things",
-          "roles": ["store-admin","sales-admin","sales-manager","sales-representative"]
-        },
-        {
-          "label": "Special Access",
-          "value": "allow-special-access",
-          "roles": ["store-admin","sales-admin"]
-        }
-      ]
-    }
-    ```
+   ```json
+   {
+     "name": "My awesome app",
+     "features": [
+       {
+         "label": "View",
+         "value": "view-awesome-things",
+         "roles": [
+           "store-admin",
+           "sales-admin",
+           "sales-manager",
+           "sales-representative",
+           "customer-admin",
+           "customer-approver",
+           "customer-buyer"
+         ]
+       },
+       {
+         "label": "Create",
+         "value": "create-awesome-things",
+         "roles": [
+           "store-admin",
+           "sales-admin",
+           "sales-manager",
+           "sales-representative"
+         ]
+       },
+       {
+         "label": "Delete",
+         "value": "delete-awesome-things",
+         "roles": [
+           "store-admin",
+           "sales-admin",
+           "sales-manager",
+           "sales-representative"
+         ]
+       },
+       {
+         "label": "Special Access",
+         "value": "allow-special-access",
+         "roles": ["store-admin", "sales-admin"]
+       }
+     ]
+   }
+   ```
 
-    Below you can find a description of each property.
+   Below you can find a description of each property.
 
-    | **Property** | **Type** | **Description** |
-    |---|---|---|
-    | `name` | string | Name of your app. |
-    | `features` | array of objects | List of features related to your app – the functionalities of your app that you want to set permissions for users to be able to access or not. |
-    |  ⤷  | object | Object containing information about each feature of your app. |
-    |    ⤷ `label` | string | Name or description of the feature. |
-    |    ⤷ `value` | string | Identifier key you want to use for the feature, as used in your app’s [custom storefront components](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-developing-custom-storefront-components). Do not use space or special characters in this field. |
-    |    ⤷ `roles` | array of strings | List with the keys for all the roles you want to associate with the permission to use the feature by default. You can find more information about each role and its key in the [Available Storefront Roles section](#available-storefront-roles) of this documentation. |
+   | **Property** | **Type**         | **Description**                                                                                                                                                                                                                                                                 |
+   | ------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | `name`       | string           | Name of your app.                                                                                                                                                                                                                                                               |
+   | `features`   | array of objects | List of features related to your app – the functionalities of your app that you want to set permissions for users to be able to access or not.                                                                                                                                  |
+   | ⤷            | object           | Object containing information about each feature of your app.                                                                                                                                                                                                                   |
+   | ⤷ `label`    | string           | Name or description of the feature.                                                                                                                                                                                                                                             |
+   | ⤷ `value`    | string           | Identifier key you want to use for the feature, as used in your app’s [custom storefront components](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-developing-custom-storefront-components). Do not use space or special characters in this field. |
+   | ⤷ `roles`    | array of strings | List with the keys for all the roles you want to associate with the permission to use the feature by default. You can find more information about each role and its key in the [Available Storefront Roles section](#available-storefront-roles) of this documentation.         |
 
 5. Make sure you refer to the `value` – the identifier key – for each feature you want to set permissions for in your [custom storefront components](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-developing-custom-storefront-components)’ code, when developing your app.
 
-    Example: in the B2B Organizations app, one of the permissions created is represented by the following object.
+   Example: in the B2B Organizations app, one of the permissions created is represented by the following object.
 
-    ```json
-    {
-      "label": "Create Cost Center",
-      "value": "create-cost-center-organization",
-      "roles": ["store-admin","sales-admin","customer-admin"]
-    }
-    ```
+   ```json
+   {
+     "label": "Create Cost Center",
+     "value": "create-cost-center-organization",
+     "roles": ["store-admin", "sales-admin", "customer-admin"]
+   }
+   ```
 
-    Therefore, in a [custom storefront component’s code](https://github.com/vtex-apps/b2b-organizations/blob/366a28add226eac5d9b104bb13a9f2cd1d574f02/react/components/CostCenterDetails.tsx) in TypeScript, whenever referring to this feature, it uses `create-cost-center-organization`.
-
+   Therefore, in a [custom storefront component’s code](https://github.com/vtex-apps/b2b-organizations/blob/366a28add226eac5d9b104bb13a9f2cd1d574f02/react/components/CostCenterDetails.tsx) in TypeScript, whenever referring to this feature, it uses `create-cost-center-organization`.
 
 Once you are done developing and installing your own app, if you have [Storefront Permissions UI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-storefront-permissions-ui), the features of your app associated with each role will be automatically loaded on the **Storefront Permissions** page. For more details on this, read our documentation on the [Storefront Permissions UI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-storefront-permissions-ui) app.
-
 
 ### GraphQL queries
 
@@ -131,7 +142,6 @@ Now that your app is integrated, you can write a GraphQL query on your app to ch
 First, you need to associate your test user to a Role containing your app's permission by following the [B2B Organizations documentation](https://developers.vtex.com/vtex-developer-docs/docs/vtex-b2b-organizations#users).
 
 It is not necessary to declare your app name nor user credentials, the query will take care of these details.
-
 
 #### checkUserPermission
 
@@ -154,9 +164,7 @@ query permissions {
 }
 ```
 
-
 Sample response:
-
 
 ```graphql
 {
@@ -173,14 +181,11 @@ Sample response:
 }
 ```
 
-
-
 #### hasUsers
 
 This query allows you to check if there are any users associated with a specific role. The response will be a boolean, with `"hasUsers": true` if there are users with this role or `false` if there are not.
 
 Sample query:
-
 
 ```graphql
 query hasUsers {
@@ -189,9 +194,7 @@ query hasUsers {
 }
 ```
 
-
 Sample response:
-
 
 ```graphql
 {
@@ -201,14 +204,11 @@ Sample response:
 }
 ```
 
-
-
 #### checkImpersonation
 
 This query allows you to check if the current user is [impersonating](https://developers.vtex.com/vtex-developer-docs/docs/vtex-b2b-organizations#impersonate-users) another user, and retrieve information on the impersonated user.
 
 Sample query:
-
 
 ```graphql
 query checkImpersonation {
@@ -222,9 +222,7 @@ query checkImpersonation {
 }
 ```
 
-
 Sample response:
-
 
 ```graphql
 {
@@ -254,9 +252,7 @@ query getSessionWatcher {
 }
 ```
 
-
 Sample response:
-
 
 ```graphql
 {
@@ -266,10 +262,7 @@ Sample response:
 }
 ```
 
-
-
 ### GraphQL mutation
-
 
 #### impersonateUser
 
@@ -277,10 +270,9 @@ Using this mutation, you can inform the `userId` to [impersonate an user](https:
 
 Sample mutation:
 
-
 ```graphql
 mutation impersonateUser($userId: ID)
-@context(provider: "vtex.storefront-permissions") {
+  @context(provider: "vtex.storefront-permissions") {
   impersonateUser(userId: $userId) {
     status
     message
@@ -292,13 +284,21 @@ mutation impersonateUser($userId: ID)
 
 If your account is not using `vtex.b2b-organizations` you may want to disable the Session Watcher to avoid unnecessary operations. To do so, set the `active` property to `false` in the mutation exemplified below.
 
+Based on the type of business, the regionalization behaviour need to change.
+The property `regionalizationType`controls how the session or search will be patched.
+The possible values are:
+
+- `DEFAULTV2` which is the default v2 regionalization from VTEX and the default for the application.
+- `DEFAULTV1` which uses the VTEX regionalization v1.
+- `PRIVATESELLER` which uses the private-seller facet filter, this should only be used in sellerWhiteLabel sellers.
+
 The response will be a boolean, with `true` for a successful operation or `false` for a failure.
 
 Sample mutation:
 
 ```graphql
 mutation setSessionWatcher {
-  sessionWatcher(active: false)
+  sessionWatcher(active: false, regionalizationType: DEFAULTV2)
 }
 ```
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -67,7 +67,10 @@ type Query {
 }
 
 type Mutation {
-  sessionWatcher(active: Boolean!): Boolean @cacheControl(scope: PRIVATE)
+  sessionWatcher(
+    active: Boolean!
+    regionalizationType: regionalizationTypeInput!
+  ): Boolean @cacheControl(scope: PRIVATE)
 
   saveRole(
     id: ID
@@ -192,6 +195,11 @@ type Profile {
   features: [Feature]!
   roleId: ID!
   scoped: Boolean
+}
+enum regionalizationTypeInput {
+  DEFAULTV2
+  PRIVATESELLER
+  DEFAULTV1
 }
 
 input FeatureInput {

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -12,7 +12,6 @@ export const sessionWatcher = async (_: any, params: any, ctx: Context) => {
   const settings: any = await vbase.getJSON('b2b_settings', app).catch(() => {
     return {}
   })
-  console.log("params:", params)
 
   const { active, regionalizationType } = params
 

--- a/node/resolvers/Mutations/Settings.ts
+++ b/node/resolvers/Mutations/Settings.ts
@@ -12,10 +12,11 @@ export const sessionWatcher = async (_: any, params: any, ctx: Context) => {
   const settings: any = await vbase.getJSON('b2b_settings', app).catch(() => {
     return {}
   })
+  console.log("params:", params)
 
-  const { active } = params
+  const { active, regionalizationType } = params
 
-  settings.sessionWatcher = { active }
+  settings.sessionWatcher = { active, regionalizationType }
 
   return vbase
     .saveJSON('b2b_settings', app, settings)

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -94,9 +94,13 @@ export const getSessionWatcher = async (_: any, __: any, ctx: Context) => {
   const settings: any = await vbase.getJSON('b2b_settings', app).catch(() => {
     return {}
   })
+  console.log("settings:", settings)
+
+  console.log(settings?.sessionWatcher?.active)
+
 
   try {
-    return settings?.sessionWatcher?.active ?? true
+    return settings?.sessionWatcher ?? true
   } catch (error) {
     logger.error({
       error,

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -90,17 +90,17 @@ export const getSessionWatcher = async (_: any, __: any, ctx: Context) => {
   } = ctx
 
   const app: string = getAppId()
+  const defaultSettings = {
+    active: true,
+    regionalizationType: 'DEFAULTV2',
+  }
 
   const settings: any = await vbase.getJSON('b2b_settings', app).catch(() => {
     return {}
   })
-  console.log("settings:", settings)
-
-  console.log(settings?.sessionWatcher?.active)
-
 
   try {
-    return settings?.sessionWatcher ?? true
+    return settings?.sessionWatcher ?? defaultSettings
   } catch (error) {
     logger.error({
       error,

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -130,7 +130,6 @@ export const Routes = {
     ctx.set('Cache-Control', 'no-cache, no-store')
 
     const isWatchActive = await getSessionWatcher(null, null, ctx)
-    console.log('is watch active', isWatchActive)
 
     if (!isWatchActive.active) {
       ctx.response.body = response
@@ -229,8 +228,6 @@ export const Routes = {
 
     let organization = (await getOrganization(user.orgId))?.data
       ?.getOrganizationById
-
-    console.log('organization:', organization)
 
     // prevent login if org is inactive
     if (organization.status === 'inactive') {
@@ -444,7 +441,10 @@ export const Routes = {
         marketingTagsResponse?.data?.getMarketingTags?.tags
 
       try {
-        if (isWatchActive.regionalizationType === 'DEFAULTV2') {
+        if (
+          isWatchActive.regionalizationType === 'DEFAULTV2' ||
+          !isWatchActive.regionalizationType
+        ) {
           const [regionId] = await checkout.getRegionId(
             address.country,
             address.postalCode,


### PR DESCRIPTION
**What problem is this solving?**
The current implementation of the storefront permissions apply both regionv2 and private-seller regionalization types at the same time. 
These two regionalisation are not supported at the same time by IS team. thus breaking the search. 

the PR is adding a new default prop to the sessionWatcher which is regionalizationType, to control the regionalization behaviour that will happen on the site. 
the Prop is set as DEFAULTV2 as default to allow backwards compatibility. 

Also adds the regionv1 option for stores that require it. 

**How should this be manually tested?**
on account: https://indolaiberia.myvtex.com/admin/b2b-organizations/organizations#/organizations add a user under the second organization in the list, this has a seller assigned and a cost center which will apply regionId and private-seller filters at the same time as seen on the segmentToken:
{
  "campaigns": null,
  "channel": "1",
  "priceTables": null,
  "regionId": "v2.E95EF045DF737D9448B8590373D19E5E",
  "utm_campaign": null,
  "utm_source": null,
  "utmi_campaign": null,
  "currencyCode": "EUR",
  "currencySymbol": "€",
  "countryCode": "ESP",
  "cultureInfo": "es-ES",
  "admin_cultureInfo": "en-US",
  "channelPrivacy": "public",
  "facets": "sellername=H'almagro;private-seller=indolaiberiaswl5;"
}

 See that the front end is broken:
 
<img width="1423" alt="Screenshot 2023-03-14 at 19 34 33" src="https://user-images.githubusercontent.com/58808189/225104171-14e617aa-bf32-457b-ab9e-78347d80653f.png">

Do the ssame thing on this workspace https://cesar--indolaiberia.myvtex.com/color/coloracion-permanente
there are no current settings so it is applying the DEFAULTV2  as shown on the segment token:
{
  "campaigns": null,
  "channel": "1",
  "priceTables": null,
  "regionId": "v2.E95EF045DF737D9448B8590373D19E5E",
  "utm_campaign": null,
  "utm_source": null,
  "utmi_campaign": null,
  "currencyCode": "EUR",
  "currencySymbol": "€",
  "countryCode": "ESP",
  "cultureInfo": "es-ES",
  "admin_cultureInfo": "en-US",
  "channelPrivacy": "public"
}

on the workspace admin grapqhl-ide, you can use the mutation to change the settings:
mutation{
  sessionWatcher(active:true, regionalizationType:DEFAULTV1)
}
<img width="1163" alt="Screenshot 2023-03-14 at 19 37 09" src="https://user-images.githubusercontent.com/58808189/225104809-5717f302-254a-4a50-b829-e28bde918196.png">

On the workspace admin grapqhl-ide, you can use the query to get the settings:
query {
  getSessionWatcher {
    active
    regionalizationType
  }
}

<img width="1141" alt="Screenshot 2023-03-14 at 19 48 54" src="https://user-images.githubusercontent.com/58808189/225107339-91d0873a-58b8-44ea-9cc7-5f5aa754ab3d.png">


