### PR TITLE
clear cart when logging out

### DIFF
--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -176,6 +176,7 @@ export const Routes = {
     }
 
     if (!email) {
+      await checkout.clearCart(orderFormId)
       ctx.response.body = response
       ctx.response.status = 200
 


### PR DESCRIPTION
**What problem is this solving?**

The cart is persisted when logging out. 

should we include it on the setting of loggin and changing companies??

**How should this be manually tested?**
login, add products to cart, logout. 
