### PR TITLE
Fix issue where documentType is always set to cpf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed issue where `documentType` is always set to cpf
+
 ## [1.33.2] - 2023-05-03
 
 ### Fixed

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -150,6 +150,7 @@ export const Routes = {
     let email = body?.authentication?.storeUserEmail?.value
     let businessName = null
     let businessDocument = null
+    let documentType = null
     let phoneNumber = null
     let tradeName = null
     let stateRegistration = null
@@ -395,6 +396,16 @@ export const Routes = {
     stateRegistration =
       costCenterResponse.data.getCostCenterById.stateRegistration
 
+    // Only require CPF if cost center contains an address in Brazil
+    // This is a workaround to avoid setting CPF as documentType for countries other than Brazil
+    if (
+      costCenterResponse?.data?.getCostCenterById?.addresses.some(
+        (address: { country: string }) => address.country === 'BRA'
+      )
+    ) {
+      documentType = Routes.PROFILE_DOCUMENT_TYPE
+    }
+
     let { salesChannel } = organization
 
     const validChannels = salesChannels.data.filter(
@@ -525,7 +536,7 @@ export const Routes = {
           .updateOrderFormProfile(orderFormId, {
             ...clUser,
             businessDocument: businessDocument || clUser.businessDocument,
-            documentType: Routes.PROFILE_DOCUMENT_TYPE,
+            documentType: documentType ?? undefined,
             stateInscription:
               stateRegistration || clUser.stateInscription || '0'.repeat(9),
           })


### PR DESCRIPTION
**What problem is this solving?**

Fix issue where `documentType` is set to`cpf` even for non Brazilian customers.
Link to issue: https://github.com/vtex-apps/storefront-permissions/issues/102

This is actually a workaround where we just check if the user cost center addresses and only force `documentType` to be`cpf` if one of them is in Brazil.

The proper fix (for which we will create a task to be tackled later) consists in using a library/service that returns the expected `documentType` for given country.

For now, at least we don't set `documentType` incorrectly to `cpf` anymore.

**How should this be manually tested?**
1. Login to a store with a user/organization where cost center does not have a Brazilian address
2. Create an order and check that `documentType` is not set to `cpf` and that proper payment methods are provided for that country/store.

