### PR TITLE
Change Team Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Change Team action metrics
+
 ## [1.35.3] - 2023-07-19
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -114,6 +114,13 @@
         "host": "{{account}}.vtexcommercestable.com.br",
         "path": "/api/scheduler/master/vtex.gmc-keep-alive"
       }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "rc.vtex.com",
+        "path": "/api/analytics/schemaless-events"
+      }
     }
   ],
   "settingsSchema": {

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { currentSchema } from '../../utils'
 import { CUSTOMER_SCHEMA_NAME } from '../../utils/constants'
+import type { ChangeTeamParams } from '../../utils/metrics/changeTeam'
+import { sendChangeTeamMetric } from '../../utils/metrics/changeTeam'
 import {
   getAllUsersByEmail,
   getOrganizationsByEmail,
@@ -620,6 +622,17 @@ export const setCurrentOrganization = async (
       },
       ctx
     )
+
+    const metricParams: ChangeTeamParams = {
+      account: sessionData?.namespaces?.account?.accountName.value,
+      userId: user.id,
+      userEmail: email,
+      orgId,
+      costCenterId: costId,
+      userRole: user.roleId,
+    }
+
+    sendChangeTeamMetric(metricParams)
 
     return { status: 'success', message: '' }
   } catch (error) {

--- a/node/utils/metrics/changeTeam.ts
+++ b/node/utils/metrics/changeTeam.ts
@@ -1,0 +1,49 @@
+import type { Metric } from './metrics'
+import { sendMetric } from './metrics'
+
+type ChangeTeamFieldsMetric = {
+  date: string
+  user_id: string
+  user_role: string
+  user_email: string
+  org_id: string
+  cost_center_id: string
+}
+
+type ChangeTeamMetric = Metric & { fields: ChangeTeamFieldsMetric }
+
+export type ChangeTeamParams = {
+  account: string
+  userId: string
+  userRole: string
+  userEmail: string
+  orgId: string
+  costCenterId: string
+}
+
+const buildMetric = (metricParams: ChangeTeamParams): ChangeTeamMetric => {
+  return {
+    name: 'b2b-suite-buyerorg-data' as const,
+    account: metricParams.account,
+    kind: 'change-team-graphql-event',
+    description: 'User change team/organization - Graphql',
+    fields: {
+      date: new Date().toISOString(),
+      user_id: metricParams.userId,
+      user_role: metricParams.userRole,
+      user_email: metricParams.userEmail,
+      org_id: metricParams.orgId,
+      cost_center_id: metricParams.costCenterId,
+    },
+  }
+}
+
+export const sendChangeTeamMetric = async (metricParams: ChangeTeamParams) => {
+  try {
+    const metric = buildMetric(metricParams)
+
+    await sendMetric(metric)
+  } catch (error) {
+    console.warn('Unable to log metrics', error)
+  }
+}

--- a/node/utils/metrics/changeTeam.ts
+++ b/node/utils/metrics/changeTeam.ts
@@ -6,8 +6,8 @@ type ChangeTeamFieldsMetric = {
   user_id: string
   user_role: string
   user_email: string
-  org_id: string
-  cost_center_id: string
+  new_org_id: string
+  new_cost_center_id: string
 }
 
 type ChangeTeamMetric = Metric & { fields: ChangeTeamFieldsMetric }
@@ -32,8 +32,8 @@ const buildMetric = (metricParams: ChangeTeamParams): ChangeTeamMetric => {
       user_id: metricParams.userId,
       user_role: metricParams.userRole,
       user_email: metricParams.userEmail,
-      org_id: metricParams.orgId,
-      cost_center_id: metricParams.costCenterId,
+      new_org_id: metricParams.orgId,
+      new_cost_center_id: metricParams.costCenterId,
     },
   }
 }

--- a/node/utils/metrics/metrics.ts
+++ b/node/utils/metrics/metrics.ts
@@ -1,0 +1,21 @@
+import axios from 'axios'
+
+const ANALYTICS_URL = 'https://rc.vtex.com/api/analytics/schemaless-events'
+
+export type ChangeTeamMetric = {
+  kind: 'change-team-graphql-event'
+  description: 'User change team/organization - Graphql'
+}
+
+export type Metric = {
+  name: 'b2b-suite-buyerorg-data'
+  account: string
+} & ChangeTeamMetric
+
+export const sendMetric = async (metric: Metric) => {
+  try {
+    await axios.post(ANALYTICS_URL, metric)
+  } catch (error) {
+    console.warn('Unable to log metrics', error)
+  }
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1428,7 +1428,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**

Send change team action metrics to Analytics

**How should this be manually tested?**

Go to https://takeda--b2bstore005.myvtex.com, and log in with a user with access to more than one organization/cost center. Select a different organization/cost center and click "Manager Current Organization". Data should appear in Analytics after one hour or so into  "vtex"."schemaless"."b2b_suite_buyerorg_data_raw" schema

![image](https://github.com/vtex-apps/storefront-permissions/assets/1576737/0ede008f-7cf5-4c50-8e1f-23f75276e9b6)

Types
```
export type ChangeTeamMetric = {
  kind: 'change-team-graphql-event'
  description: 'User change team/organization - Graphql'
}

export type Metric = {
  name: 'b2b-suite-buyerorg-data'
  account: string
} & ChangeTeamMetric

type ChangeTeamFieldsMetric = {
  date: string
  user_id: string
  user_role: string
  user_email: string
  org_id: string
  cost_center_id: string
}

type ChangeTeamMetric = Metric & { fields: ChangeTeamFieldsMetric }
```

Query example and results
```
SELECT
    payload.account,
    payload.kind,
    payload.fields.date,
    payload.fields.user_id,
    payload.fields.user_role,
    payload.fields.user_email,
    payload.fields.org_id,
    payload.fields.cost_center_id

FROM "vtex"."schemaless"."b2b_suite_buyerorg_data_raw"
WHERE payload.name = 'b2b-suite-buyerorg-data'
and payload.kind in ('change-team-graphql-event')
order by ingestion_time desc
```

![image](https://github.com/vtex-apps/storefront-permissions/assets/1576737/391662a2-35c9-48f8-8b85-b7734f440354)


