### PR TITLE
Change to selectedAddresses when updating OrderForm Shipping Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Change to use selectedAddresses field when updating OrderForm Shipping Data
+
 ## [1.37.0] - 2023-11-06
 
 ### Added

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -533,10 +533,10 @@ export const Routes = {
       promises.push(
         checkout
           .updateOrderFormShipping(orderFormId, {
-            address: {
+            selectedAddresses: [{
               ...address,
               geoCoordinates: address.geoCoordinates ?? [],
-            },
+            }],
             clearAddressIfPostalCodeNotFound: false,
           })
           .catch((error) => {


### PR DESCRIPTION
**What problem is this solving?**
Changing to send selectedAddresses instead of address when updating OrderForm Shipping Data. 

Currently, there is a [known issue](https://help.vtex.com/known-issues/ki--931225) from checkout which impact B2B Suite.

**How should this be manually tested?**

**Screenshots or example usage:**