### PR TITLE
fix: adjust b2b-organizations-graphql integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust b2b-organizations-graphql integration
+
 ## [1.39.1] - 2024-02-09
 
 ### Fixed

--- a/node/clients/Organizations.ts
+++ b/node/clients/Organizations.ts
@@ -1,5 +1,5 @@
 import type { InstanceOptions, IOContext } from '@vtex/api'
-import { AppClient, GraphQLClient } from '@vtex/api'
+import { AppGraphQLClient } from '@vtex/api'
 
 import { QUERIES } from '../resolvers/Routes/utils'
 import { getTokenToHeader } from './index'
@@ -13,12 +13,9 @@ const getPersistedQuery = () => {
   }
 }
 
-export class OrganizationsGraphQLClient extends AppClient {
-  protected graphql: GraphQLClient
-
+export class OrganizationsGraphQLClient extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.graphql-server@1.x', ctx, options)
-    this.graphql = new GraphQLClient(this.http)
+    super('vtex.b2b-organizations-graphql@0.x', ctx, options)
   }
 
   public getOrganizationById = async (orgId: string): Promise<unknown> => {
@@ -81,7 +78,6 @@ export class OrganizationsGraphQLClient extends AppClient {
           headers: getTokenToHeader(this.context),
           locale: this.context.locale,
         },
-        url: '/graphql',
       }
     )
   }

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -18,7 +18,6 @@ export const getTokenToHeader = (ctx: IOContext) => {
   const { sessionToken } = ctx
 
   return {
-    'x-vtex-credential': ctx.authToken,
     VtexIdclientAutCookie: token,
     cookie: `VtexIdclientAutCookie=${token}`,
     'x-vtex-session': sessionToken ?? '',

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "1.39.1",
   "dependencies": {
-    "@vtex/api": "6.46.0",
+    "@vtex/api": "6.46.1",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "cookie": "^0.3.1",
@@ -21,7 +21,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.46.0",
+    "@vtex/api": "6.46.1",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/Routes/utils/index.ts
+++ b/node/resolvers/Routes/utils/index.ts
@@ -49,13 +49,13 @@ export const QUERIES = {
     }`,
   getMarketingTags: `
     query ($costId: ID!) {
-      getMarketingTags(costId: $costId) @context(provider: "vtex.b2b-organizations-graphql") {
+      getMarketingTags(costId: $costId){
         tags
       }
     }
   `,
   getOrganizationById: `query Organization($id: ID!){
-      getOrganizationById(id: $id) @context(provider: "vtex.b2b-organizations-graphql"){
+      getOrganizationById(id: $id){
         name
         tradeName
         status

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -190,10 +190,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
-  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
+"@vtex/api@6.46.1":
+  version "6.46.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.1.tgz#55a8755ae48f5400e7f1ed1921cd547950bb7a2a"
+  integrity sha512-geoxVvyWoQpOQ70Zmx3M8SBkRoGOS/bp9Gy26M+iCue63jofVSwmFz1zf66EaHA1PKOJNRgQPFwY+oeDE1U2lQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**

- We have an integration between storefront-permissions and b2b-organizations, and it is necessary to validate authentication in the request. But for some reason the storefront-permissions can't forward the cookie headers, and the token doesn't come in b2b-organization-graphql.

So, we change the integration structure and the graphql server intermediation to use the header `x-vtex-caller` as `vtex.storefront-permissions` and allow in b2b-organizations.

**How should this be manually tested?**

- Login in the b2b store.

**Screenshots or example usage:**