### PR TITLE
Changed to remove special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Changed to remove space instead of character
+
 ## [1.39.3] - 2024-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
+
 - Changed to remove space instead of character
 
 ## [1.39.3] - 2024-02-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
 - Changed to remove space instead of character
 
 ## [1.39.3] - 2024-02-27

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -377,7 +377,7 @@ export const Routes = {
 
     businessDocument =
       costCenterResponse.data.getCostCenterById.businessDocument?.replace(
-        /\D/,
+        /\s*/,
         ''
       )
 

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -377,7 +377,7 @@ export const Routes = {
 
     businessDocument =
       costCenterResponse.data.getCostCenterById.businessDocument?.replace(
-        /\s*/,
+        /[^a-zA-Z0-9]*/,
         ''
       )
 


### PR DESCRIPTION
**What problem is this solving?**
Currently when an organization's corporate document starts with letters, the first digit is removed after accessing checkout.

This PR is changing this logic to only remove special characters

Solving KI 920703