### PR TITLE
Revert auth changes due to rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Reverted changes from versions 1.40.3, 1.40.2 and 1.40.1
+
 ## [1.40.3] - 2024-04-24
 
 ### Fixed

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -12,19 +12,14 @@ import { Schema } from './schema'
 import VtexId from './vtexId'
 
 export const getTokenToHeader = (ctx: IOContext) => {
-  const adminToken = ctx.adminUserAuthToken ?? ctx.authToken
-  const userToken = ctx.storeUserAuthToken ?? null
-  const { sessionToken, account } = ctx
+  const token =
+    ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken
 
-  let allCookies = `VtexIdclientAutCookie=${adminToken}`
-
-  if (userToken) {
-    allCookies += `; VtexIdclientAutCookie_${account}=${userToken}`
-  }
+  const { sessionToken } = ctx
 
   return {
-    VtexIdclientAutCookie: adminToken,
-    cookie: allCookies,
+    VtexIdclientAutCookie: token,
+    cookie: `VtexIdclientAutCookie=${token}`,
     'x-vtex-session': sessionToken ?? '',
   }
 }

--- a/node/directives/checkAdminAccess.ts
+++ b/node/directives/checkAdminAccess.ts
@@ -23,16 +23,7 @@ export class CheckAdminAccess extends SchemaDirectiveVisitor {
       }
 
       try {
-        const authUser = await identity.validateToken({
-          token: adminUserAuthToken,
-        })
-
-        if (!authUser?.audience || authUser?.audience !== 'admin') {
-          logger.warn({
-            message: `CheckAdminAccess: No valid user found by admin token`,
-          })
-          throw new ForbiddenError('Unauthorized Access')
-        }
+        await identity.validateToken({ token: adminUserAuthToken })
       } catch (err) {
         logger.warn({
           error: err,

--- a/node/directives/checkUserAccess.ts
+++ b/node/directives/checkUserAccess.ts
@@ -3,8 +3,6 @@ import type { GraphQLField } from 'graphql'
 import { defaultFieldResolver } from 'graphql'
 import { SchemaDirectiveVisitor } from 'graphql-tools'
 
-import { getActiveUserByEmail } from '../resolvers/Queries/Users'
-
 export async function checkUserOrAdminTokenAccess(
   ctx: Context,
   operation?: string
@@ -44,20 +42,6 @@ export async function checkUserOrAdminTokenAccess(
           operation,
         })
         authUser = null
-      } else {
-        const user = (await getActiveUserByEmail(
-          null,
-          { email: authUser?.user },
-          ctx
-        )) as { roleId: string } | null
-
-        if (!user?.roleId) {
-          logger.warn({
-            message: `CheckUserAccess: No valid role for user found by store user token`,
-            operation,
-          })
-          authUser = null
-        }
       }
     } catch (err) {
       logger.warn({

--- a/node/directives/checkUserAccess.ts
+++ b/node/directives/checkUserAccess.ts
@@ -24,17 +24,7 @@ export async function checkUserOrAdminTokenAccess(
 
   if (adminUserAuthToken) {
     try {
-      const authUser = await identity.validateToken({
-        token: adminUserAuthToken,
-      })
-
-      if (!authUser?.audience || authUser?.audience !== 'admin') {
-        logger.warn({
-          message: `CheckUserAccess: No valid user found by admin token`,
-          operation,
-        })
-        throw new ForbiddenError('Unauthorized Access')
-      }
+      await identity.validateToken({ token: adminUserAuthToken })
     } catch (err) {
       logger.warn({
         error: err,


### PR DESCRIPTION
**What problem is this solving?**

Revert latest changes as these broke multiple stores.
The following versions were deprecated: 1.40.1, 1.40.2 and 1.40.3
Current valid version: 1.40.0