### PR TITLE
fix:  storefront permissions considers inactive organizations [KI 927174]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Storefront considers the active organizations when setting the user's profile
+
 ## [1.41.0] - 2024-07-01
 
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "1.41.0",
   "dependencies": {
-    "@vtex/api": "6.46.1",
+    "@vtex/api": "6.47.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "cookie": "^0.3.1",
@@ -21,7 +21,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.46.1",
+    "@vtex/api": "6.47.0",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/Routes/utils/index.ts
+++ b/node/resolvers/Routes/utils/index.ts
@@ -71,7 +71,7 @@ export const QUERIES = {
       }
     }`,
   getOrganizationsByEmail: `query Organizations($email: String!) {
-       getOrganizationsByEmail(email: $email) @context(provider: "vtex.b2b-organizations-graphql") {
+       getOrganizationsByEmail(email: $email) {
           id
           organizationStatus
           costId

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -190,10 +190,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.46.1":
-  version "6.46.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.1.tgz#55a8755ae48f5400e7f1ed1921cd547950bb7a2a"
-  integrity sha512-geoxVvyWoQpOQ70Zmx3M8SBkRoGOS/bp9Gy26M+iCue63jofVSwmFz1zf66EaHA1PKOJNRgQPFwY+oeDE1U2lQ==
+"@vtex/api@6.47.0":
+  version "6.47.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
+  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1428,7 +1428,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**
When a user has more than one organization assigned and the first registered one is inactive, the system does not recognize that the user has other active organizations after login.

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

- Create two organizations and assign the same user/email to both;
- Inactivate the first organization created;
- Log in to the website.