### PR TITLE
fix: provide app token on calls to b2b-organizations-graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Provide app token on calls to b2b-organizations-graphql app
+
 ## [1.44.4] - 2024-09-03
 
 ### Fixed

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -12,7 +12,7 @@ import { Schema } from './schema'
 import VtexId from './vtexId'
 
 export const getTokenToHeader = (ctx: IOContext) => {
-  const adminToken = ctx.adminUserAuthToken ?? ctx.authToken
+  const adminToken = ctx.authToken
   const userToken = ctx.storeUserAuthToken
   const { sessionToken, account } = ctx
 


### PR DESCRIPTION
**What problem is this solving?**

Provide app token on calls to b2b-organizations-graphql instead of admin/user tokens as these were already validated at this point. More details on: [https://vtex-dev.atlassian.net/browse/B2BTEAM-1796](https://vtex-dev.atlassian.net/browse/B2BTEAM-1796)