### PR TITLE
fix: add await to requests to properly handle login with inactive orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add await to requests to properly handle inactive organizations on login
+
 ## [1.44.5] - 2024-09-04
 
 ### Fixed

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -244,7 +244,7 @@ export const Routes = {
     response['storefront-permissions'].organization.value = user.orgId
 
     const getOrganization = async (orgId: any): Promise<any> => {
-      return organizations.getOrganizationById(orgId).catch((error) => {
+      return await organizations.getOrganizationById(orgId).catch((error) => {
         logger.error({
           error,
           message: 'setProfile.graphqlGetOrganizationById',
@@ -293,8 +293,7 @@ export const Routes = {
         if (organizationList) {
           organization = (await getOrganization(organizationList.id))?.data
             ?.getOrganizationById
-
-          setActiveUserByOrganization(
+          await setActiveUserByOrganization(
             null,
             {
               costId: organizationList.costId,

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -244,7 +244,7 @@ export const Routes = {
     response['storefront-permissions'].organization.value = user.orgId
 
     const getOrganization = async (orgId: any): Promise<any> => {
-      return await organizations.getOrganizationById(orgId).catch((error) => {
+      return organizations.getOrganizationById(orgId).catch((error) => {
         logger.error({
           error,
           message: 'setProfile.graphqlGetOrganizationById',

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1428,7 +1428,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
**What problem is this solving?**
Add await to requests during login. This guarantees the user is associated to an active org, even if it is also part of inactive orgs. Otherwise, these requests might not complete before the active org is set to the user, ending up setting the wrong org (an inactive one).