### PR TITLE
fix: remove unnecessary b2b_users storage on vbase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove unnecessary b2b_users storage on vbase
+
 ## [1.44.6] - 2024-09-05
 
 ### Fixed

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -206,7 +206,7 @@ export const addUser = async (_: any, params: any, ctx: Context) => {
       params: {
         ...params,
         clId: cId,
-      }
+      },
     })
 
     return { status: 'success', message: '', id: cId }
@@ -235,7 +235,7 @@ export const updateUser = async (_: any, params: any, ctx: Context) => {
     await createPermission({
       lm,
       masterdata,
-      params
+      params,
     })
 
     return { status: 'success', message: '', id: params.clId }

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -116,7 +116,7 @@ const updateUserFields = async ({ masterdata, fields, id }: any) => {
   return DocumentId
 }
 
-const createPermission = async ({ masterdata, vbase, params }: any) => {
+const createPermission = async ({ masterdata, params }: any) => {
   const {
     roleId,
     canImpersonate,
@@ -129,7 +129,7 @@ const createPermission = async ({ masterdata, vbase, params }: any) => {
     id,
   } = params
 
-  const { DocumentId } = await masterdata
+  await masterdata
     .createOrUpdateEntireDocument({
       dataEntity: config.name,
       fields: {
@@ -157,25 +157,11 @@ const createPermission = async ({ masterdata, vbase, params }: any) => {
 
       throw error
     })
-
-  if (DocumentId) {
-    await vbase.saveJSON('b2b_users', email, {
-      canImpersonate,
-      clId,
-      costId,
-      email,
-      id: DocumentId,
-      name,
-      orgId,
-      roleId,
-      userId,
-    })
-  }
 }
 
 export const addUser = async (_: any, params: any, ctx: Context) => {
   const {
-    clients: { masterdata, lm, vbase },
+    clients: { masterdata, lm },
     vtex: { logger },
   } = ctx
 
@@ -220,8 +206,7 @@ export const addUser = async (_: any, params: any, ctx: Context) => {
       params: {
         ...params,
         clId: cId,
-      },
-      vbase,
+      }
     })
 
     return { status: 'success', message: '', id: cId }
@@ -323,15 +308,13 @@ export const deleteUserProfile = async (_: any, params: any, ctx: Context) => {
 
 export const deleteUser = async (_: any, params: any, ctx: Context) => {
   const {
-    clients: { masterdata, vbase },
+    clients: { masterdata },
     vtex: { logger },
   } = ctx
 
-  const { id, email } = params
+  const { id } = params
 
   try {
-    await vbase.deleteFile('b2b_users', email).catch(() => null)
-
     await masterdata.deleteDocument({
       dataEntity: config.name,
       id,

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -222,7 +222,7 @@ export const addUser = async (_: any, params: any, ctx: Context) => {
 
 export const updateUser = async (_: any, params: any, ctx: Context) => {
   const {
-    clients: { masterdata, lm, vbase },
+    clients: { masterdata, lm },
     vtex: { logger },
   } = ctx
 
@@ -235,8 +235,7 @@ export const updateUser = async (_: any, params: any, ctx: Context) => {
     await createPermission({
       lm,
       masterdata,
-      params,
-      vbase,
+      params
     })
 
     return { status: 'success', message: '', id: params.clId }


### PR DESCRIPTION
**What problem is this solving?**

The `b2b_users` data on vbase was only being written but never read. This PR removes this entity usage from vbase.

This data was originally read on the `checkPermissions` function, but it was removed months ago due to an issue with vbase.

Now, this is the use cases that writes the most to vbase, but is its data is never read, hence, there is no point in keeping it.