### PR TITLE
Session: return early if storeUserEmail is not populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,64 +7,80 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- In session provider, return early if storeUserEmail is not populated
+
 ## [1.44.7] - 2024-09-25
 
 ### Fixed
+
 - Remove unnecessary b2b_users storage on vbase
 
 ## [1.44.6] - 2024-09-05
 
 ### Fixed
+
 - Add await to requests to properly handle inactive organizations on login
 
 ## [1.44.5] - 2024-09-04
 
 ### Fixed
+
 - Provide app token on calls to b2b-organizations-graphql app
 
 ## [1.44.4] - 2024-09-03
 
 ### Fixed
+
 - Add sort to searchDocumentsWithPaginationInfo at getAllUsers
 
 ## [1.44.3] - 2024-08-22
 
 ### Fixed
+
 - add new auth metric field
 
 ## [1.44.2] - 2024-08-21
 
 ### Fixed
+
 - addUser function to not accept invalid cost center
 
 ## [1.44.1] - 2024-08-19
 
 ### Added
+
 - Session audit metrics
 
 ## [1.44.0] - 2024-08-14
 
 ### Changed
+
 - Changed the token validation directive of some operations
 
 ## [1.43.5] - 2024-08-08
 
 ### Fixed
+
 - Storefront considers the active organizations when setting the user's profile
 
 ## [1.43.4] - 2024-08-07
 
 ### Changed
+
 - Changed the token validation directive of some operations
 
 ## [1.43.3] - 2024-07-31
 
 ### Changed
+
 - Changed the token validation directive of some operations
 
 ## [1.43.2] - 2024-07-29
 
 ### Added
+
 - Add enforcement of new validation for admin and api tokens
 - Add more details to admin and api token validation metric
 

--- a/node/directives/validateStoreUserAccess.ts
+++ b/node/directives/validateStoreUserAccess.ts
@@ -122,7 +122,7 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
 
       const { hasStoreToken, hasValidStoreToken } = await validateStoreToken(
         context,
-        (storeUserAuthToken as string) ?? (adminUserAuthToken as string)
+        storeUserAuthToken as string
       )
 
       // add store token metrics

--- a/node/directives/validateStoreUserAccess.ts
+++ b/node/directives/validateStoreUserAccess.ts
@@ -122,7 +122,7 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
 
       const { hasStoreToken, hasValidStoreToken } = await validateStoreToken(
         context,
-        storeUserAuthToken as string
+        (storeUserAuthToken as string) ?? (adminUserAuthToken as string)
       )
 
       // add store token metrics

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -172,6 +172,13 @@ export const Routes = {
       return
     }
 
+    if (!email) {
+      ctx.response.body = response
+      ctx.response.status = 200
+
+      return
+    }
+
     if (b2bImpersonate) {
       try {
         user = (await getUser({
@@ -210,13 +217,6 @@ export const Routes = {
       response['storefront-permissions'].storeUserEmail.value =
         telemarketingEmail
       email = telemarketingEmail
-    }
-
-    if (!email) {
-      ctx.response.body = response
-      ctx.response.status = 200
-
-      return
     }
 
     if (user === null) {

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -165,14 +165,7 @@ export const Routes = {
 
     const ignoreB2B = body?.public?.removeB2B?.value
 
-    if (ignoreB2B) {
-      ctx.response.body = response
-      ctx.response.status = 200
-
-      return
-    }
-
-    if (!email) {
+    if (ignoreB2B || !email) {
       ctx.response.body = response
       ctx.response.status = 200
 


### PR DESCRIPTION
**What problem is this solving?**

A bug has been identified during the Helmet House project, having to do with B2B impersonation. 

Part of the issue is that the `vtex_session` cookie has a longer expiration (~5 days) than the `VtexidClientAutCookie` (~1 day). Therefore, when returning to the store after 24 hours the user is likely to have an expired `VtexidClientAutCookie` but a non-expired session. 

If the user had an active B2B impersonation session when they last used the site, when they return their session will become corrupted due to Storefront-Permission's `setProfile` logic which does not expect this scenario. This can cause undesirable side effects; for example in Helmet House's case, the user is in a "half-logged in" state when they should actually be prompted to log in again (the storefront is not meant to be accessible by anonymous users). 

The existing logic in the Storefront Permissions `setProfile` flow is this:
- check if there is a `storeUserEmail` in the session input `authentication` namespace
- check if there is a user ID in the session input `public.impersonate` namespace, and if so, look up the email for that user
- if neither of these emails are provided, return early

This PR adjusts the logic like so:
- check if there is a `storeUserEmail` in the session input `authentication` namespace
- if not, return early
- check if there is a user ID in the session input `public.impersonate` namespace, and if so, look up the email for that user

This correctly results in the user with an expired cookie to be prompted to log in again. Once they've logged in, their impersonation session will continue, and this is fine.

**How should this be manually tested?**

The new app is linked in https://arthur--helmethouseprod.myvtex.com . Contact me on Slack for user credentials, or I can present a before/after demo of the fix.
