### PR TITLE
Adjust session provider early return logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust session provider early return logic
+
 ## [1.44.8] - 2024-10-02
 
 ### Fixed

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -165,14 +165,14 @@ export const Routes = {
 
     const ignoreB2B = body?.public?.removeB2B?.value
 
-    if (ignoreB2B || !email) {
+    if (ignoreB2B) {
       ctx.response.body = response
       ctx.response.status = 200
 
       return
     }
 
-    if (b2bImpersonate) {
+    if (email && b2bImpersonate) {
       try {
         user = (await getUser({
           masterdata,
@@ -210,6 +210,13 @@ export const Routes = {
       response['storefront-permissions'].storeUserEmail.value =
         telemarketingEmail
       email = telemarketingEmail
+    }
+
+    if (!email) {
+      ctx.response.body = response
+      ctx.response.status = 200
+
+      return
     }
 
     if (user === null) {


### PR DESCRIPTION
**What problem is this solving?**

Adjusts the logic of the previous PR so as not to break VTEX "legacy" call center operator impersonation functionality. 

In the B2B impersonation scenario, the session provider must validate that the user has a `storeUserEmail` in their session -- in other words, they must be logged in to the storefront to be able to impersonate another B2B user.

In the legacy impersonation scenario, the user must be accessing `account.myvtex.com` as an admin user with the call center operator role, but not necessarily logged into the storefront. The `storeUserEmail` should not be validated in this case. 

**How should this be manually tested?**

New version linked and tested in https://arthur--helmethouseprod.myvtex.com