### PR TITLE
[FSEUS-521] Error changing Cost Center after placing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Error changing Cost Center after placing order
+
 ## [1.44.8] - 2024-10-02
 
 ### Fixed

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -375,7 +375,7 @@ export const impersonateUser = async (_: any, params: any, ctx: Context) => {
   const { userId } = params
 
   try {
-    setChangeSession({
+    await setChangeSession({
       context: ctx,
       publicKey: 'impersonate',
       value: userId,
@@ -664,7 +664,7 @@ export const setCurrentOrganization = async (
 
     sendChangeTeamMetric(metricParams)
 
-    setChangeSession({
+    await setChangeSession({
       context: ctx,
       publicKey: 'b2bCurrentCostCenter',
       value: costId,
@@ -697,7 +697,7 @@ export const ignoreB2BSessionData = async (
     cookies.get('vtex_session') ?? request.header?.sessiontoken
 
   try {
-    setChangeSession({
+    await setChangeSession({
       context: ctx,
       publicKey: 'removeB2B',
       value: enabled,

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -12,6 +12,8 @@ import {
 const config: any = currentSchema('b2b_users')
 
 const MAX_RETRY = 5
+const RETRY_BACKOFF_FACTOR_MS = 100
+const MAX_BACKOFF_MS = 1000
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 const setChangeSession = async (
@@ -39,7 +41,10 @@ const setChangeSession = async (
 
     if (countRetry < MAX_RETRY) {
       countRetry++
-      const backoff = 2 ** countRetry * 500
+      const backoff = Math.min(
+        2 ** (countRetry - 1) * RETRY_BACKOFF_FACTOR_MS,
+        MAX_BACKOFF_MS
+      )
 
       await delay(backoff)
 

--- a/vtex.session/configuration.json
+++ b/vtex.session/configuration.json
@@ -4,7 +4,7 @@
       "authentication": ["storeUserEmail"],
       "checkout": ["orderFormId"],
       "impersonate": ["storeUserEmail", "storeUserId"],
-      "public": ["impersonate", "removeB2B"]
+      "public": ["impersonate", "removeB2B", "b2bCurrentCostCenter"]
     },
     "output": {
       "public": ["facets", "sc", "regionId"],


### PR DESCRIPTION
**What problem is this solving?**

### Fixed

When the user changes organization right after placing an order, the session is not updated.
The PR consists of adding additional session control, forcing the session watcher to update the namespace values.
Also implemented a reusable retry functionality to updateSession
 

**How should this be manually tested?**
- Log in with a user that has more than one Organization/Cost Center
- Place an order
- Still, on the Order Placed page, change the Organization/Cost Center
- If there is an error, it won't update the selection (visible in the top bar)

