### PR TITLE
fix: Use return instead of throwing a duplicate email error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use return instead of throwing a duplicate email error.
+
 ## [1.44.9] - 2024-10-03
 
 ### Fixed

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -195,9 +195,10 @@ export const addUser = async (_: any, params: any, ctx: Context) => {
         (org: any) => org.orgId === params.orgId && org.costId === params.costId
       )
     ) {
-      throw new Error(
-        `User with email ${params.email} already exists in the organization and cost center`
-      )
+      return {
+        message: `Email already exists in the organization and cost center`,
+        status: 'duplicated-organization',
+      }
     }
 
     await createPermission({


### PR DESCRIPTION
**What problem is this solving?**

We found a lot of error logs when the user already exists and someone tries to add the same email.
So, we removed the throwing to avoid excessive logs of errors treated.

**How should this be manually tested?**

Try to add an existing email user to the Buyer organization.

**Screenshots or example usage:**
![image](https://github.com/user-attachments/assets/38be5318-fd22-4c66-b1f8-c94f14d2b0ca)