### PR TITLE
Feat/acl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added optional argument to validateAdminUserAccess and validateStoreUserAccess directives to check specific user permissions via LM API.
+
 ## [1.44.6] - 2024-09-05
 
 ### Fixed

--- a/graphql/directives.graphql
+++ b/graphql/directives.graphql
@@ -1,7 +1,11 @@
 directive @checkUserAccess on FIELD | FIELD_DEFINITION
-directive @validateStoreUserAccess on FIELD | FIELD_DEFINITION
+directive @validateAdminUserAccess(
+  orgPermission: String
+) on FIELD | FIELD_DEFINITION
+directive @validateStoreUserAccess(
+  orgPermission: String
+) on FIELD | FIELD_DEFINITION
 directive @checkAdminAccess on FIELD | FIELD_DEFINITION
-directive @validateAdminUserAccess on FIELD | FIELD_DEFINITION
 directive @withSession on FIELD_DEFINITION
 directive @withSender on FIELD_DEFINITION
 directive @withUserPermissions on FIELD_DEFINITION

--- a/node/directives/helper.ts
+++ b/node/directives/helper.ts
@@ -3,7 +3,8 @@ import { isUserPartOfBuyerOrg } from '../resolvers/Queries/Users'
 export const validateAdminToken = async (
   context: Context,
   adminUserAuthToken: string,
-  metricFields: any
+  metricFields: any,
+  orgPermission?: 'buyer_organization_edit' | 'buyer_organization_view'
 ): Promise<{
   hasAdminToken: boolean
   hasValidAdminToken: boolean
@@ -49,6 +50,18 @@ export const validateAdminToken = async (
           account,
           authUser.id
         )
+
+        if (
+          hasValidAdminToken &&
+          orgPermission &&
+          authUser.tokenType === 'user'
+        ) {
+          await lm.checkUserAdminPermission(
+            account,
+            authUser.user,
+            orgPermission
+          )
+        }
       }
     } catch (err) {
       // noop so we leave hasValidAdminToken as false

--- a/node/directives/validateAdminUserAccess.ts
+++ b/node/directives/validateAdminUserAccess.ts
@@ -14,6 +14,7 @@ import {
 export class ValidateAdminUserAccess extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
     const { resolve = defaultFieldResolver } = field
+    const { orgPermission } = this.args
 
     field.resolve = async (
       root: any,
@@ -44,7 +45,8 @@ export class ValidateAdminUserAccess extends SchemaDirectiveVisitor {
       const { hasAdminToken, hasValidAdminToken } = await validateAdminToken(
         context,
         adminUserAuthToken as string,
-        metricFields
+        metricFields,
+        orgPermission
       )
 
       // add admin token metrics

--- a/node/directives/validateStoreUserAccess.ts
+++ b/node/directives/validateStoreUserAccess.ts
@@ -15,6 +15,7 @@ import {
 export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
   public visitFieldDefinition(field: GraphQLField<any, any>) {
     const { resolve = defaultFieldResolver } = field
+    const { orgPermission } = this.args
 
     field.resolve = async (
       root: any,
@@ -45,7 +46,8 @@ export class ValidateStoreUserAccess extends SchemaDirectiveVisitor {
       const { hasAdminToken, hasValidAdminToken } = await validateAdminToken(
         context,
         adminUserAuthToken as string,
-        metricFields
+        metricFields,
+        orgPermission
       )
 
       // add admin token metrics

--- a/node/utils/constants.ts
+++ b/node/utils/constants.ts
@@ -7,3 +7,5 @@ export const CUSTOMER_REQUIRED_FIELDS = [
   'dataEntityId',
 ]
 export const ROLES_VBASE_ID = 'allRolesVbId'
+
+export const B2B_LM_PRODUCT_CODE = '97' // resource name on lincense manager = B2B


### PR DESCRIPTION
**What problem is this solving?**

Currently, when accessing organization management, any user can make any change. The goal is to implement a minimum control of viewing/changing.
VTEX already has two features in the license manager that are not used, called:
Buyer Organization View
Buyer Organization Edit
These two features could be used to facilitate the requested changes

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

**Screenshots or example usage:**


Related to: https://github.com/vtex-apps/b2b-organizations-graphql/pull/181