### PR TITLE
fix: add pagination to getOrganizationsByEmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added pagination to `getOrganizationsByEmail` and applied it in `setProfile` to handle large datasets efficiently.
+
 ## [1.45.1] - 2024-10-28
 
 ### Fixed

--- a/node/clients/Organizations.ts
+++ b/node/clients/Organizations.ts
@@ -60,13 +60,13 @@ export class OrganizationsGraphQLClient extends AppGraphQLClient {
     })
   }
 
-  public getOrganizationsByEmail = async (email: string) => {
+  public getOrganizationsByEmail = async (email: string, limit: number, offset: number) => {
     return this.query({
       extensions: getPersistedQuery(),
       query: QUERIES.getOrganizationsByEmail,
-      variables: { email },
-    }) as Promise<GetOrganizationsByEmailResponse>
-  }
+      variables: { email, limit, offset },
+    }) as Promise<GetOrganizationsByEmailResponse>;
+  };
 
   private query = async (param: {
     query: string

--- a/node/resolvers/Routes/utils/index.ts
+++ b/node/resolvers/Routes/utils/index.ts
@@ -72,14 +72,14 @@ export const QUERIES = {
         }
       }
     }`,
-  getOrganizationsByEmail: `query Organizations($email: String!) {
-       getOrganizationsByEmail(email: $email){
-          id
-          organizationStatus
-          costId
-          orgId
-          costCenterName
-       }
+  getOrganizationsByEmail: `query Organizations($email: String!, $limit: Int!, $offset: Int!) {
+    getOrganizationsByEmail(email: $email, limit: $limit, offset: $offset) {
+      id
+      organizationStatus
+      costId
+      orgId
+      costCenterName
+    }
   }`,
 }
 


### PR DESCRIPTION
**What problem is this solving?**

This change fixes the timeout issue for representatives with 900+ linked organizations by implementing pagination. It prevents performance degradation by fetching data in smaller chunks, ensuring successful login even with many organizations.

I chose backend pagination to handle data efficiently on the server, reducing client-side complexity and improving performance.

**How should this be manually tested?**

1. **Link a representative to 900+ organizations.**
2. **Attempt login to the marketplace.**
   - Ensure the login succeeds without timeouts and that pagination works correctly in the backend.

**Screenshots or example usage:**

No visual changes, only a backend fix to implement pagination for fetching organizations, resolving the timeout issue for representatives with many organizations.

**IMPORTANT:** TESTS ARE STILL PENDING FOR THIS CHANGE.