### PR TITLE
Fix: Prevent unnecessary cart clearing on checkout step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Clear cart only changed Hash (OrgId+CostId)
+
 ## [1.45.1] - 2024-10-28
 
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "1.45.1",
   "dependencies": {
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "cookie": "^0.3.1",
@@ -21,7 +21,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -6,6 +6,7 @@ import { getSessionWatcher } from '../Queries/Settings'
 import { getActiveUserByEmail, getUserByEmail } from '../Queries/Users'
 import { generateClUser } from './utils'
 import { getUser, setActiveUserByOrganization } from '../Mutations/Users'
+import { toHash } from '../../utils'
 
 export const Routes = {
   PROFILE_DOCUMENT_TYPE: 'cpf',
@@ -131,6 +132,9 @@ export const Routes = {
         userId: {
           value: '',
         },
+        hash: {
+          value: '',
+        },
       },
     }
 
@@ -250,6 +254,11 @@ export const Routes = {
         })
       })
     }
+
+    const hash = toHash(`${user.orgId}|${user.costId}`)
+    const changed = body?.['storefront-permissions']?.hash?.value !== hash
+
+    response['storefront-permissions'].hash.value = hash
 
     const [
       organizationResponse,
@@ -449,7 +458,7 @@ export const Routes = {
       response.public.sc.value = salesChannel.toString()
     }
 
-    if (orderFormId) {
+    if (changed && orderFormId) {
       try {
         const {
           uiSettings: { clearCart },

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -256,7 +256,7 @@ export const Routes = {
     }
 
     const hash = toHash(`${user.orgId}|${user.costId}`)
-    const changed = body?.['storefront-permissions']?.hash?.value !== hash
+    const hashChanged = body?.['storefront-permissions']?.hash?.value !== hash
 
     response['storefront-permissions'].hash.value = hash
 
@@ -458,7 +458,7 @@ export const Routes = {
       response.public.sc.value = salesChannel.toString()
     }
 
-    if (changed && orderFormId) {
+    if (hashChanged && orderFormId) {
       try {
         const {
           uiSettings: { clearCart },

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -190,10 +190,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1428,7 +1428,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/vtex.session/configuration.json
+++ b/vtex.session/configuration.json
@@ -4,7 +4,8 @@
       "authentication": ["storeUserEmail"],
       "checkout": ["orderFormId"],
       "impersonate": ["storeUserEmail", "storeUserId"],
-      "public": ["impersonate", "removeB2B", "b2bCurrentCostCenter"]
+      "public": ["impersonate", "removeB2B", "b2bCurrentCostCenter"],
+      "storefront-permissions": ["hash"]
     },
     "output": {
       "public": ["facets", "sc", "regionId"],
@@ -15,7 +16,8 @@
         "costcenter",
         "priceTables",
         "collections",
-        "userId"
+        "userId",
+        "hash"
       ]
     }
   }


### PR DESCRIPTION
# Context  
A customer reported an issue where, after completing a purchase, attempting another purchase results in all items being removed from the cart at the checkout step.  

## Steps to reproduce:  
1. Go to the store login page.  
2. Log in with a test user.  
3. Add items to the cart (OrderFormId A).  
4. Go to checkout and complete the order (OrderPlaced page). A new `OrderFormId B` is generated automatically.  
5. From OrderPlaced, go back to home and add new items to the cart (OrderFormId B).  
6. Go to checkout. Items are displayed correctly initially.  
7. Proceed to the next step, and all items are removed.  

⚠️ **This issue is intermittent and does not occur for all users/accounts.**  

# Root Cause  
- Upon entering the checkout for the second time, `storefront-permissions` triggers a `SetProfile` API call.  
- Even though all session data remains the same, `SetProfile` is designed to clear the cart when the `OrderFormId` is present.  
- The issue occurs because `SetProfile` is mistakenly detecting a session change and invoking the cart reset logic.  

# Solution  
✅ Implemented a **session hash validation** to prevent unnecessary cart clearing.  
- The hash is generated using `OrganizationId + CostCenterId`.  
- Cart clearing is now only triggered if a real organization or cost center change occurs (e.g., switching organizations).  
- This ensures that even if `SetProfile` is triggered multiple times due to other events, the cart remains intact as long as the session hash remains unchanged.  

# Impact  
- 🛒 Prevents unexpected cart clearing in checkout flow.  
- 🚀 Ensures smoother user experience for B2B customers.  
- 📉 Reduces unnecessary session-related API calls.  
