### PR TITLE
Use custom master data client to improve performance on setProfile method

### DIFF
--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -10,6 +10,7 @@ import { OrganizationsGraphQLClient } from './Organizations'
 import { SalesChannel } from './salesChannel'
 import { Schema } from './schema'
 import VtexId from './vtexId'
+import { MasterDataExtended } from './masterDataExtended'
 
 export const getTokenToHeader = (ctx: IOContext) => {
   const adminToken = ctx.authToken
@@ -68,5 +69,9 @@ export class Clients extends IOClients {
 
   public get fullSessions() {
     return this.getOrSet('fullSessions', FullSessions)
+  }
+
+  public get masterDataExtended() {
+    return this.getOrSet('masterDataExtended', MasterDataExtended)
   }
 }

--- a/node/clients/masterDataExtended.ts
+++ b/node/clients/masterDataExtended.ts
@@ -1,0 +1,23 @@
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+
+export class MasterDataExtended extends JanusClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, {
+      ...options,
+      headers: {
+        VtexIdClientAutCookie: context.authToken,
+      },
+    })
+  }
+
+  public getDocumentById = async (
+    dataEntity: String,
+    id: String,
+    fields: String[]
+  ) => 
+    await this.http.get<any>(
+      `/api/dataentities/${dataEntity}/documents/${id}?_fields=${fields.join(',')}`
+    )
+  
+}

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -187,16 +187,17 @@ export const getUserByEmail = async (_: any, params: any, ctx: Context) => {
 
 export const getUserById = async (_: any, params: any, ctx: Context) => {
   const {
-    clients: { masterdata },
+    clients: { masterDataExtended },
     vtex: { logger },
   } = ctx
 
   try {
     const { id } = params
 
-    const cl: any = await masterdata.getDocument({
-      dataEntity: CUSTOMER_SCHEMA_NAME,
-      fields: [
+    const cl: any = await masterDataExtended.getDocumentById(
+      CUSTOMER_SCHEMA_NAME,
+      id,
+      [
         'email',
         'firstName',
         'lastName',
@@ -211,8 +212,7 @@ export const getUserById = async (_: any, params: any, ctx: Context) => {
         'corporatePhone',
         'isCorporate',
       ],
-      id,
-    })
+    )
 
     return cl ?? null
   } catch (error) {

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -93,6 +93,7 @@ export const Routes = {
       clients: {
         organizations,
         masterdata,
+        masterDataExtended,
         checkout,
         profileSystem,
         salesChannel: salesChannelClient,
@@ -247,7 +248,19 @@ export const Routes = {
     response['storefront-permissions'].organization.value = user.orgId
 
     const getOrganization = async (orgId: any): Promise<any> => {
-      return organizations.getOrganizationById(orgId).catch((error) => {
+      return masterDataExtended.getDocumentById(
+        'organizations',
+        orgId,
+        [
+          'name',
+          'tradeName',
+          'status',
+          'priceTables',
+          'salesChannel',
+          'collections',
+          'sellers'
+        ],
+      ).catch((error) => {
         logger.error({
           error,
           message: 'setProfile.graphqlGetOrganizationById',
@@ -299,7 +312,7 @@ export const Routes = {
       }
     }
 
-    let organization = organizationResponse?.data?.getOrganizationById
+    let organization: any = organizationResponse
 
     // prevent login if org is inactive
     if (organization.status === 'inactive') {
@@ -322,8 +335,7 @@ export const Routes = {
         )
 
         if (organizationList) {
-          organization = (await getOrganization(organizationList.id))?.data
-            ?.getOrganizationById
+          organization = await getOrganization(organizationList.id)
           await setActiveUserByOrganization(
             null,
             {


### PR DESCRIPTION
**What problem is this solving?**

It was identified that the requests to getOrganizationById from the graphQL layer and getUser using the Master Data factory was generating a bigger response time for these specific methods. This was causing a timeout in the Session System, returning a 504 error.
The goal of this PR is to request Master Data directly from the storefront-permissions to improve the performance for setProfile method.

**How should this be manually tested?**

Create a session for an user that exists in the B2B Organizations.

**Screenshots or example usage:**