### PR TITLE
chore: update dependency major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update dependency major version
+
 ## [1.45.3] - 2025-04-22
 
 ### Changed

--- a/node/clients/Organizations.ts
+++ b/node/clients/Organizations.ts
@@ -11,15 +11,15 @@ import type {
 const getPersistedQuery = () => {
   return {
     persistedQuery: {
-      provider: 'vtex.b2b-organizations-graphql@0.x',
-      sender: 'vtex.storefront-permissions@1.x',
+      provider: 'vtex.b2b-organizations-graphql@1.x',
+      sender: 'vtex.storefront-permissions@2.x',
     },
   }
 }
 
 export class OrganizationsGraphQLClient extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.b2b-organizations-graphql@0.x', ctx, options)
+    super('vtex.b2b-organizations-graphql@1.x', ctx, options)
   }
 
   public getOrganizationById = async (orgId: string): Promise<unknown> => {


### PR DESCRIPTION
**What problem is this solving?**

Update major dependencies.

**How should this be manually tested?**

The new major versions for the following apps must be installed in other to test (which can be done only after all PRs updating versions are merged):
```
vtex.b2b-organizations-graphql@1.x
vtex.b2b-quotes-graphql@3.x
vtex.storefront-permissions@2.x
vtex.storefront-permissions-ui@2.x
vtex.storefront-permissions-components@1.x
vtex.b2b-quotes@2.x
vtex.b2b-organizations@2.x
vtex.b2b-checkout-settings@2.x
vtex.b2b-admin-customers@1.x
vtex.b2b-theme@4.x
vtex.b2b-orders-history@1.x
vtex.b2b-my-account@1.x
vtex.b2b-suite@1.x
```