### PR TITLE
Feature/set pricetable mutation 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+.qodo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enhanced price table handling in `setProfile` to prioritize user's selected price table in the response
 
 ### Changed
-- Updated `b2b_users` schema version to v0.1.3
+- Add `selectedPriceTable` to `b2b_users` schema
 
 ## [1.45.3] - 2025-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated `b2b_users` schema version to v0.1.3
-- Modified `setCurrentOrganization` to reset user's selected price table when changing organizations
-- Enhanced session hash generation to include selected price table information
 
 ## [1.45.3] - 2025-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New mutation `setCurrentPriceTable` to allow users to select a specific price table from their organization's available price tables
+- New field `selectedPriceTable` to `b2b_users` schema to persist user's price table preference
+- Enhanced price table handling in `setProfile` to prioritize user's selected price table in the response
+
+### Changed
+- Updated `b2b_users` schema version to v0.1.3
+- Modified `setCurrentOrganization` to reset user's selected price table when changing organizations
+- Enhanced session hash generation to include selected price table information
+
 ## [1.45.3] - 2025-04-22
 
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -168,6 +168,11 @@ type Mutation {
   ignoreB2BSessionData(enabled: Boolean!): MutationResponse
     @withSession
     @cacheControl(scope: PRIVATE)
+
+  setCurrentPriceTable(priceTable: String): MutationResponse
+    @withSession
+    @cacheControl(scope: PRIVATE)
+    @withSender
 }
 
 type UserImpersonation {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -173,6 +173,7 @@ type Mutation {
     @withSession
     @cacheControl(scope: PRIVATE)
     @withSender
+    @validateStoreUserAccess
 }
 
 type UserImpersonation {

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -52,7 +52,7 @@ export default [
   },
   {
     name: 'b2b_users',
-    version: 'v0.1.3',
+    version: 'v0.1.2',
     body: {
       properties: {
         roleId: {

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -52,7 +52,7 @@ export default [
   },
   {
     name: 'b2b_users',
-    version: 'v0.1.2',
+    version: 'v0.1.3',
     body: {
       properties: {
         roleId: {
@@ -91,6 +91,10 @@ export default [
           type: 'boolean',
           title: 'Current Profile active',
         },
+        selectedPriceTable: {
+          type: ['null', 'string'],
+          title: 'Selected Price Table',
+        },
       },
       'v-immediate-indexing': true,
       'v-indexed': [
@@ -102,6 +106,7 @@ export default [
         'email',
         'canImpersonate',
         'active',
+        'selectedPriceTable',
       ],
       'v-cache': false,
     },

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -714,8 +714,6 @@ export const setCurrentOrganization = async (
   }
 }
 
-// node/resolvers/Mutations/Users.ts
-
 export const setCurrentPriceTable = async (
   _: any,
   params: { priceTable: string | null },

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -159,8 +159,11 @@ const updateUserFields = async ({ masterdata, fields, id }: any) => {
   return DocumentId
 }
 
-const addSelectedPriceTableToB2bUser = async ({ masterdata, fields, id }: any) => {
-  
+const addSelectedPriceTableToB2bUser = async ({
+  masterdata,
+  fields,
+  id,
+}: any) => {
   const { DocumentId } = await masterdata
     .createOrUpdatePartialDocument({
       dataEntity: config.name,
@@ -723,6 +726,7 @@ export const setCurrentPriceTable = async (
     vtex: { logger },
     clients: { masterdata },
   } = ctx
+
   const { sessionData } = ctx.vtex as any
 
   try {
@@ -733,15 +737,17 @@ export const setCurrentPriceTable = async (
       'storefront-permissions': {
         organization: { value: orgId },
         userId: { value: userId },
-      }
+      },
     } = sessionData.namespaces
 
     if (!orgId || !userId) {
       const error = 'User not properly authenticated with organization context'
+
       logger.error({
         error,
         message: 'setCurrentPriceTable.error.noOrgContext',
       })
+
       return { status: 'error', message: error }
     }
 
@@ -754,12 +760,14 @@ export const setCurrentPriceTable = async (
 
     if (!organization?.priceTables?.includes(priceTable)) {
       const error = 'Price table not allowed for this organization'
+
       logger.error({
         error,
         message: 'setCurrentPriceTable.error.invalidPriceTable',
         priceTable,
         orgId,
       })
+
       return { status: 'error', message: error }
     }
 
@@ -776,6 +784,7 @@ export const setCurrentPriceTable = async (
       error,
       message: 'setCurrentPriceTable.error',
     })
+
     return { status: 'error', message: error }
   }
 }

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -795,7 +795,6 @@ export const getOrganizationsByEmail = async (
   } = ctx
 
   const { email } = params
-
   try {
     return (await getAllUsersByEmail(null, { email }, ctx)).map(
       (user: any) => ({

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -72,6 +72,7 @@ export const getAllUsers = async ({
           'userId',
           'canImpersonate',
           'active',
+          'selectedPriceTable',
         ],
         pagination: {
           page: currentPage,
@@ -268,6 +269,7 @@ export const getB2BUserById = async (_: any, params: any, ctx: Context) => {
         'costId',
         'userId',
         'canImpersonate',
+        'selectedPriceTable'
       ],
       id,
     })

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -269,7 +269,7 @@ export const getB2BUserById = async (_: any, params: any, ctx: Context) => {
         'costId',
         'userId',
         'canImpersonate',
-        'selectedPriceTable'
+        'selectedPriceTable',
       ],
       id,
     })
@@ -797,6 +797,7 @@ export const getOrganizationsByEmail = async (
   } = ctx
 
   const { email } = params
+
   try {
     return (await getAllUsersByEmail(null, { email }, ctx)).map(
       (user: any) => ({

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -3,7 +3,7 @@ import { json } from 'co-body'
 
 import { getRole } from '../Queries/Roles'
 import { getSessionWatcher } from '../Queries/Settings'
-import { getActiveUserByEmail, getUserByEmail } from '../Queries/Users'
+import { getActiveUserByEmail, getUserByEmail, getB2BUserById } from '../Queries/Users'
 import { generateClUser } from './utils'
 import { getUser, setActiveUserByOrganization } from '../Mutations/Users'
 import { toHash } from '../../utils'
@@ -363,10 +363,16 @@ export const Routes = {
     businessName = organization.name
     tradeName = organization.tradeName
 
-    if (organization.priceTables?.length) {
+    // Get the selectedPriceTable from B2B_USER
+
+    const userWithPriceTable = await getB2BUserById(null, {id: user.id}, ctx ) as {selectedPriceTable: string}
+
+    const selectedPriceTable = userWithPriceTable?.selectedPriceTable ? userWithPriceTable?.selectedPriceTable : organization.priceTables.join(',')
+
+    if (selectedPriceTable || organization.priceTables?.length) {
       response[
         'storefront-permissions'
-      ].priceTables.value = `${organization.priceTables.join(',')}`
+      ].priceTables.value = `${selectedPriceTable}`
     }
 
     let facets = [] as any

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -3,7 +3,11 @@ import { json } from 'co-body'
 
 import { getRole } from '../Queries/Roles'
 import { getSessionWatcher } from '../Queries/Settings'
-import { getActiveUserByEmail, getUserByEmail, getB2BUserById } from '../Queries/Users'
+import {
+  getActiveUserByEmail,
+  getUserByEmail,
+  getB2BUserById,
+} from '../Queries/Users'
 import { generateClUser } from './utils'
 import { getUser, setActiveUserByOrganization } from '../Mutations/Users'
 import { toHash } from '../../utils'
@@ -365,9 +369,15 @@ export const Routes = {
 
     // Get the selectedPriceTable from B2B_USER
 
-    const userWithPriceTable = await getB2BUserById(null, {id: user.id}, ctx ) as {selectedPriceTable: string}
+    const userWithPriceTable = (await getB2BUserById(
+      null,
+      { id: user.id },
+      ctx
+    )) as { selectedPriceTable: string }
 
-    const selectedPriceTable = userWithPriceTable?.selectedPriceTable ? userWithPriceTable?.selectedPriceTable : organization.priceTables.join(',')
+    const selectedPriceTable = userWithPriceTable?.selectedPriceTable
+      ? userWithPriceTable?.selectedPriceTable
+      : organization.priceTables.join(',')
 
     if (selectedPriceTable || organization.priceTables?.length) {
       response[

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -14,6 +14,7 @@ import {
   setActiveUserByOrganization,
   setCurrentOrganization,
   updateUser,
+  setCurrentPriceTable
 } from './Mutations/Users'
 import { getFeaturesByModule, listFeatures } from './Queries/Features'
 import { getRole, hasUsers, listRoles } from './Queries/Roles'
@@ -49,6 +50,7 @@ export const resolvers = {
     setActiveUserByOrganization,
     setCurrentOrganization,
     updateUser,
+    setCurrentPriceTable
   },
   Query: {
     checkCustomerSchema,

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -14,7 +14,7 @@ import {
   setActiveUserByOrganization,
   setCurrentOrganization,
   updateUser,
-  setCurrentPriceTable
+  setCurrentPriceTable,
 } from './Mutations/Users'
 import { getFeaturesByModule, listFeatures } from './Queries/Features'
 import { getRole, hasUsers, listRoles } from './Queries/Roles'
@@ -50,7 +50,7 @@ export const resolvers = {
     setActiveUserByOrganization,
     setCurrentOrganization,
     updateUser,
-    setCurrentPriceTable
+    setCurrentPriceTable,
   },
   Query: {
     checkCustomerSchema,


### PR DESCRIPTION
**What problem is this solving?**

This feature allows storefront permissions app to set a custom priceTable based on user scope. 

The mutation setCurrentPriceTable sets the selectedPriceTable field on b2b_users entity for the logged-in user. 

The restriction in place is that the priceTable needs to be one of the user's organization "priceTables" field.

The Updated setProfile method will check for selectedPriceTable in the user record in b2b_users. If null, will default to the user's organization's priceTables field. 

**How should this be manually tested?**

1. Link the app to your workspace
2. Run selectedPriceTable mutation, passing a priceTable name present in the user's organization priceTables list.
3. Run any mutation that runs setProfile, such as setCurrentOrganization
4. Check the session to see if the priceTable is added to the priceTables key in "profile" and "storefront-permissions" namespace.