### PR TITLE
add: set user price table mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+.qodo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add new setCurrentPriceTable mutation that allows a specific price table to be selected for the user
+
 ## [2.0.0] - 2025-05-27
 
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -168,6 +168,12 @@ type Mutation {
   ignoreB2BSessionData(enabled: Boolean!): MutationResponse
     @withSession
     @cacheControl(scope: PRIVATE)
+
+  setCurrentPriceTable(priceTable: String): MutationResponse
+    @withSession
+    @cacheControl(scope: PRIVATE)
+    @withSender
+    @validateStoreUserAccess
 }
 
 type UserImpersonation {
@@ -205,6 +211,7 @@ type User {
   email: String!
   canImpersonate: Boolean
   active: Boolean
+  selectedPriceTable: String
 }
 
 type Organization {

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -91,6 +91,10 @@ export default [
           type: 'boolean',
           title: 'Current Profile active',
         },
+        selectedPriceTable: {
+          type: ['null', 'string'],
+          title: 'Selected Price Table',
+        },
       },
       'v-immediate-indexing': true,
       'v-indexed': [
@@ -102,6 +106,7 @@ export default [
         'email',
         'canImpersonate',
         'active',
+        'selectedPriceTable',
       ],
       'v-cache': false,
     },

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -120,6 +120,7 @@ export const getUser = async ({
         'roleId',
         'userId',
         'active',
+        'selectedPriceTable',
       ],
       pagination: {
         page: 1,
@@ -137,6 +138,34 @@ export const getUser = async ({
 const updateUserFields = async ({ masterdata, fields, id }: any) => {
   const { DocumentId } = await masterdata
     .createOrUpdateEntireDocument({
+      dataEntity: config.name,
+      fields,
+      id,
+      schema: config.version,
+    })
+    .then((response: { DocumentId: string }) => {
+      return response
+    })
+    .catch((error: any) => {
+      if (error.response.status < 400) {
+        return {
+          DocumentId: id,
+        }
+      }
+
+      throw error
+    })
+
+  return DocumentId
+}
+
+const addSelectedPriceTableToB2bUser = async ({
+  masterdata,
+  fields,
+  id,
+}: any) => {
+  const { DocumentId } = await masterdata
+    .createOrUpdatePartialDocument({
       dataEntity: config.name,
       fields,
       id,
@@ -682,6 +711,84 @@ export const setCurrentOrganization = async (
     logger.error({
       error,
       message: 'updateCurrentOrganization.error',
+    })
+
+    return { status: 'error', message: error }
+  }
+}
+
+export const setCurrentPriceTable = async (
+  _: any,
+  params: { priceTable: string | null },
+  ctx: Context
+) => {
+  const {
+    vtex: { logger },
+    clients: { masterdata },
+  } = ctx
+
+  const { sessionData } = ctx.vtex as any
+
+  try {
+    let { priceTable } = params
+
+    // allow setting user priceTable back to null
+    if (priceTable === undefined) priceTable = null
+
+    // Get current user's organization
+    const {
+      'storefront-permissions': {
+        organization: { value: orgId },
+        userId: { value: userId },
+      },
+    } = sessionData.namespaces
+
+    if (!orgId || !userId) {
+      const error = 'User not properly authenticated with organization context'
+
+      logger.error({
+        error,
+        message: 'setCurrentPriceTable.error.noOrgContext',
+      })
+
+      return { status: 'error', message: error }
+    }
+
+    // Get organization data to validate price table
+    const organization = await ctx.clients.masterDataExtended.getDocumentById(
+      'organizations',
+      orgId,
+      ['priceTables']
+    )
+
+    if (
+      priceTable != null &&
+      !organization?.priceTables?.includes(priceTable)
+    ) {
+      const error = 'Price table not allowed for this organization'
+
+      logger.error({
+        error,
+        message: 'setCurrentPriceTable.error.invalidPriceTable',
+        priceTable,
+        orgId,
+      })
+
+      return { status: 'error', message: error }
+    }
+
+    // Update user's selected price table
+    await addSelectedPriceTableToB2bUser({
+      masterdata,
+      fields: { selectedPriceTable: priceTable },
+      id: userId,
+    })
+
+    return { status: 'success', message: '' }
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'setCurrentPriceTable.error',
     })
 
     return { status: 'error', message: error }

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -72,6 +72,7 @@ export const getAllUsers = async ({
           'userId',
           'canImpersonate',
           'active',
+          'selectedPriceTable',
         ],
         pagination: {
           page: currentPage,
@@ -268,6 +269,7 @@ export const getB2BUserById = async (_: any, params: any, ctx: Context) => {
         'costId',
         'userId',
         'canImpersonate',
+        'selectedPriceTable',
       ],
       id,
     })

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -3,7 +3,11 @@ import { json } from 'co-body'
 
 import { getRole } from '../Queries/Roles'
 import { getSessionWatcher } from '../Queries/Settings'
-import { getActiveUserByEmail, getUserByEmail } from '../Queries/Users'
+import {
+  getActiveUserByEmail,
+  getUserByEmail,
+  getB2BUserById,
+} from '../Queries/Users'
 import { generateClUser } from './utils'
 import { getUser, setActiveUserByOrganization } from '../Mutations/Users'
 import { toHash } from '../../utils'
@@ -364,9 +368,19 @@ export const Routes = {
     tradeName = organization.tradeName
 
     if (organization.priceTables?.length) {
+      const userWithPriceTable = (await getB2BUserById(
+        null,
+        { id: user.id },
+        ctx
+      )) as { selectedPriceTable: string }
+
+      const selectedPriceTable = userWithPriceTable?.selectedPriceTable
+        ? userWithPriceTable.selectedPriceTable
+        : organization.priceTables.join(',')
+
       response[
         'storefront-permissions'
-      ].priceTables.value = `${organization.priceTables.join(',')}`
+      ].priceTables.value = `${selectedPriceTable}`
     }
 
     let facets = [] as any

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -14,6 +14,7 @@ import {
   setActiveUserByOrganization,
   setCurrentOrganization,
   updateUser,
+  setCurrentPriceTable,
 } from './Mutations/Users'
 import { getFeaturesByModule, listFeatures } from './Queries/Features'
 import { getRole, hasUsers, listRoles } from './Queries/Roles'
@@ -49,6 +50,7 @@ export const resolvers = {
     setActiveUserByOrganization,
     setCurrentOrganization,
     updateUser,
+    setCurrentPriceTable,
   },
   Query: {
     checkCustomerSchema,


### PR DESCRIPTION
**What problem is this solving?**

This is a re-do of the [PR#178](https://github.com/vtex-apps/storefront-permissions/pull/178) that was reverted previously.
On top of what the original PR do, this change also:
* allows setting the user price table back to null
* fix a bug that would crash login if the organization had no associated price tables
* add the selectedPriceTable field on the response of user related queries.

Original PR description:
This feature allows storefront permissions app to set a custom priceTable based on user scope.

The mutation setCurrentPriceTable sets the selectedPriceTable field on b2b_users entity for the logged-in user.

The restriction in place is that the priceTable needs to be one of the user's organization "priceTables" field.

The Updated setProfile method will check for selectedPriceTable in the user record in b2b_users. If null, will default to the user's organization's priceTables field

