### PR TITLE
Added name to indexed fields for b2b_users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Add `name` to `b2b_users` `v-indexed` to enable native sorting by name
+- Extend `listUsersPaginated` search to filter by `name` in addition to `email`
+
 ## [3.3.2] - 2026-03-06
 
 ### Changed

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -52,7 +52,7 @@ export default [
   },
   {
     name: 'b2b_users',
-    version: 'v0.1.3',
+    version: 'v0.1.2',
     body: {
       properties: {
         roleId: {

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -52,7 +52,7 @@ export default [
   },
   {
     name: 'b2b_users',
-    version: 'v0.1.2',
+    version: 'v0.1.3',
     body: {
       properties: {
         roleId: {
@@ -104,6 +104,7 @@ export default [
         'orgId',
         'costId',
         'email',
+        'name',
         'canImpersonate',
         'active',
         'selectedPriceTable',

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -507,7 +507,7 @@ export const listUsersPaginated = async (
   let whereSearchFields: any[] = []
 
   if (search && search.length > 0) {
-    const fields = ['email']
+    const fields = ['email', 'name']
 
     whereSearchFields = fields.map((field) => `${field}="*${search}*"`)
   }


### PR DESCRIPTION
**What problem is this solving?**
Enable search and filter by name `b2b_users`

**Screenshots or example usage:**
<img width="2706" height="3400" alt="image" src="https://github.com/user-attachments/assets/6ac65f4f-a342-4c1d-b5ae-fb42bb4e404b" />
<img width="2612" height="3262" alt="image" src="https://github.com/user-attachments/assets/4fd9a984-e5d9-47c7-93df-1105b7fc5fcd" />
<img width="2744" height="1672" alt="image" src="https://github.com/user-attachments/assets/f52c00fb-504c-4d7e-9f7c-1181b9afe407" />
