### PR TITLE
[B2BTEAM-3597] Introducing major-based schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 .qodo
+.cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Scope schema sync hash by app major version (VBase key `${app}-v{N}`)
+- Bump Master Data schema versions to `v3.x` to align with app major 3.x
+
 ## [3.3.3] - 2026-06-12
 
 ### Changed

--- a/node/mdSchema.ts
+++ b/node/mdSchema.ts
@@ -1,7 +1,13 @@
+const SCHEMA_MAJOR = '3'
+
+export const B2B_ROLES_SCHEMA_VERSION = `v${SCHEMA_MAJOR}.0.3`
+export const B2B_PROFILES_SCHEMA_VERSION = `v${SCHEMA_MAJOR}.0.2`
+export const B2B_USERS_SCHEMA_VERSION = `v${SCHEMA_MAJOR}.1.2`
+
 export default [
   {
     name: 'b2b_roles',
-    version: 'v0.0.3',
+    version: B2B_ROLES_SCHEMA_VERSION,
     body: {
       properties: {
         name: {
@@ -31,7 +37,7 @@ export default [
   },
   {
     name: 'b2b_profiles',
-    version: 'v0.0.2',
+    version: B2B_PROFILES_SCHEMA_VERSION,
     body: {
       properties: {
         roleId: {
@@ -52,7 +58,7 @@ export default [
   },
   {
     name: 'b2b_users',
-    version: 'v0.1.2',
+    version: B2B_USERS_SCHEMA_VERSION,
     body: {
       properties: {
         roleId: {

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.checkout-ui-custom",
   "version": "3.3.3",
   "dependencies": {
-    "@vtex/api": "6.50.1",
+    "@vtex/api": "6.51.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "cookie": "^0.3.1",
@@ -21,7 +21,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.50.1",
+    "@vtex/api": "6.51.0",
     "@vtex/prettier-config": "^0.3.1",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",

--- a/node/resolvers/Queries/Settings.ts
+++ b/node/resolvers/Queries/Settings.ts
@@ -1,5 +1,5 @@
 import schemas from '../../mdSchema'
-import { toHash } from '../../utils'
+import { getSchemaSettingsVBaseKey, toHash } from '../../utils'
 import { syncRoles } from '../Mutations/Roles'
 import type { ErrorResponse } from '../Routes/utils'
 
@@ -17,8 +17,9 @@ export const getAppSettings = async (_: any, __: any, ctx: Context) => {
   } = ctx
 
   const app: string = getAppId()
+  const settingsKey = getSchemaSettingsVBaseKey(app)
 
-  const settings = (await vbase.getJSON('b2b_settings', app).catch(() => {
+  const settings = (await vbase.getJSON('b2b_settings', settingsKey).catch(() => {
     return {}
   })) as {
     adminSetup: {
@@ -73,7 +74,7 @@ export const getAppSettings = async (_: any, __: any, ctx: Context) => {
         }
       })
 
-    await vbase.saveJSON('b2b_settings', app, settings)
+    await vbase.saveJSON('b2b_settings', settingsKey, settings)
   }
 
   const roles: any = await syncRoles(ctx).catch(() => [])

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -12,6 +12,15 @@ import roleNames from '../roleNames'
 
 export * from './cookie'
 
+export const getAppMajorVersion = (): string => {
+  const version = process.env.VTEX_APP_ID?.split('@')[1] ?? ''
+
+  return version.split('.')[0] || '3'
+}
+
+export const getSchemaSettingsVBaseKey = (app: string): string =>
+  `${app}-v${getAppMajorVersion()}`
+
 export const toHash = (obj: any) => {
   return crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex')
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -603,10 +603,10 @@
   resolved "https://registry.yarnpkg.com/@types/shimmer/-/shimmer-1.2.0.tgz#9b706af96fa06416828842397a70dfbbf1c14ded"
   integrity sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==
 
-"@vtex/api@6.50.1":
-  version "6.50.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.50.1.tgz#a86578982a7aac7c7a8df2b9ec3df18bc43f01f2"
-  integrity sha512-4IlmYwCXKpkdpN2KN6NkPuRwnjet3ilSoET3PBOTTdZqE/mnuvIxRZRaQy+Yp7Gxu0XKAVdp/8SQJhsJaa6Unw==
+"@vtex/api@6.51.0":
+  version "6.51.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.51.0.tgz#97aeb306619ff49fd890595b90568883eaf77d83"
+  integrity sha512-vRWKB4G1FPPt67rwWx+xGLanuP5y+M9SVmbKu3PzlTrqgq/aW/mINSUGa/Nhm64UBqIQCkVic7/smZ7kKFq52w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -2177,7 +2177,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.1"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/a0b5ee91861f31b6ec845146b4906faf5172c430"
   dependencies:


### PR DESCRIPTION
## What problem is this solving?

Accounts running **two different majors of the same app** (e.g. `vtex.storefront-permissions@1.x` and `@3.x`) share a **single VBase hash** for Master Data schema auto-sync. Each major has different schema definitions, so they produce different hashes. When one major runs `getAppSettings`, it overwrites the hash saved by the other — triggering repeated `createOrUpdateSchema` calls on every request and causing an **infinite sync loop**.

A related issue: app major `3.x` was still registering and querying MD schemas under legacy `v0.x` versions (`v0.0.3`, `v0.0.2`, `v0.1.2`), which could be overwritten or conflict with schemas managed by another installed major.

This change fixes both problems by:
1. **Scoping the schema sync hash per app major** — VBase key `${app}-v{N}` (e.g. `vtex.storefront-permissions-v3`) instead of the global `${app}` key
2. **Bumping MD schema versions to `v3.x`** — `v3.0.3`, `v3.0.2`, `v3.1.2` — aligned with app major 3.x

Legacy VBase keys and `v0.x` schemas are **not migrated or deleted**, preserving backward compatibility for accounts still on older majors.

---

## How should this be manually tested?


1. **Link the branch** in a dev workspace, or use the existing [Workspace](https://wender--b2bstoreqa.myvtex.com/)
   ```bash
   vtex link
   ```

2. **Trigger schema sync** via GraphQL:
   ```graphql
   query {
     getAppSettings @context(provider: "vtex.storefront-permissions") {
       adminSetup
     }
   }
   ```
   - Should return successfully with a `schemaHash` value

3. **Verify per-major VBase key** in bucket `b2b_settings`:
   - Confirm a new key exists: `vtex.storefront-permissions-v3`
   - Legacy key `vtex.storefront-permissions` (if present) should remain untouched

4. **Verify MD schema versions** via Master Data API:
   ```bash
   GET /api/dataentities/b2b_roles/schemas/v3.0.3
   GET /api/dataentities/b2b_profiles/schemas/v3.0.2
   GET /api/dataentities/b2b_users/schemas/v3.1.2
   ```
   - All should return HTTP 200 with the expected schema body

5. **Confirm sync is idempotent** — call `getAppSettings` again:
   - Same `schemaHash` should be returned
   - No repeated schema registration in logs

6. **Verify MD read/write still works** with the new schema versions:
   ```graphql
   query {
     listUsersPaginated(page: 1, pageSize: 5, sortedBy: "email") {
       data { name email }
       pagination { total }
     }
   }
   ```

7. **(Optional) Two-major isolation** — with both `1.x` and `3.x` installed in the same account:
   - Trigger `getAppSettings` on each major
   - Confirm each writes to its own VBase key (`-v1` vs `-v3`) without overwriting the other's hash
   - Confirm no sync loop in app logs

8. **Regression check** — `sessionWatcher` settings should still work (stored on the legacy `${app}` key, unchanged):
   ```graphql
   query {
     getSessionWatcher @context(provider: "vtex.storefront-permissions")
   }
   ```

**Screenshots or example usage:**
<img width="1060" height="296" alt="image" src="https://github.com/user-attachments/assets/ec7ad35f-d17a-4b63-a176-4dec1d7d17c5" />
<img width="818" height="941" alt="image" src="https://github.com/user-attachments/assets/56919c6b-b927-4f0f-b43b-44c1b52786a1" />
<img width="1698" height="779" alt="image" src="https://github.com/user-attachments/assets/31cfd822-ce24-4a4e-85ae-bf3b529cb2f5" />



