### PR TITLE
fix: defer sales channel to binding when organization has none set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New app setting `deferSalesChannelToBinding` (default `false`). When enabled, if the organization has no `salesChannel` set, `setProfile` no longer defaults the session/cart sales channel to the account's first active sales channel, avoiding a write race with apps like `vtex.binding-selector` that also set the sales channel from the chosen binding. [B2BTEAM-3593]
+
 ## [3.5.0] - 2026-07-15
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ It also allows you to configure available permissions when developing your own a
 
 For B2B session behavior related to **cost center address selection** and **region overwrite** (multiple addresses per cost center, optional region from postal code/country), see [Cost center address and region](COST_CENTER_ADDRESS_AND_REGION.md).
 
+For B2B session behavior related to **sales channel coexistence with binding selection** (multi-binding stores using `vtex.binding-selector`), see [Sales channel coexistence with binding selection](SALES_CHANNEL_BINDING_COEXISTENCE.md).
+
 The **Storefront Permissions** app does not contain an interface – it operates “backstage”, storing the predefined roles and serving as a bridge to communicate with other apps in order to check user permissions. If you would like to manage roles and app permissions using the VTEX Admin interface, you must also install the [Storefront Permissions UI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-storefront-permissions-ui) app. As an optional feature, you can install the [Admin Customers](https://developers.vtex.com/vtex-developer-docs/docs/vtex-admin-customers) app for additional customer management capabilities.
 
 

--- a/docs/SALES_CHANNEL_BINDING_COEXISTENCE.md
+++ b/docs/SALES_CHANNEL_BINDING_COEXISTENCE.md
@@ -1,0 +1,49 @@
+# Sales channel coexistence with binding selection
+
+This document describes how **Storefront Permissions** decides the sales channel (`sc`) it writes to the session and cart in the `setProfile` session transform, and the opt-in setting that lets it coexist with apps that also set the sales channel from the shopper's chosen binding (e.g. `vtex.binding-selector`). It is intended for developers integrating with the session or debugging sales channel behavior in multi-binding B2B stores.
+
+## Overview
+
+`setProfile` resolves a sales channel from the organization's `salesChannel` field and, whenever it resolves one, unconditionally writes it to `public.sc` in the session and re-stamps the checkout order form with it. When the organization has **no** `salesChannel` configured, the app used to always fall back to the account's first active sales channel.
+
+In stores that also use bindings to serve multiple locales/sales channels (`vtex.binding-selector`), that app sets the sales channel from the binding the shopper picked, restamping the cart the same way. Both apps write to the same shared `public.sc` session field from independent triggers, with no defined precedence — whichever one runs last wins. In practice, this means a shopper can switch bindings, see the storefront reflect the new locale, and still have checkout/cart retain the wrong sales channel context.
+
+## 1. Session contract (output)
+
+| Field | Description |
+|-------|-------------|
+| `public.sc` | The resolved sales channel. Left untouched (no write) when the organization has no `salesChannel` and `deferSalesChannelToBinding` is on — see below. |
+| `public.regionId` | Unaffected by this setting: region lookup uses its own independent sales-channel fallback so it always has a value to query with, even when the session's `sc` write is deferred. |
+
+This is part of the same `setProfile` output already declared in `vtex.session/configuration.json` (`public.sc`); no new session input/output field was added.
+
+## 2. App setting (feature flag)
+
+| Setting | Default | Effect when **off** | Effect when **on** |
+|--------|--------|---------------------|--------------------|
+| **Defer sales channel to binding** (`deferSalesChannelToBinding`) | `false` | An organization with no `salesChannel` configured falls back to the account's first active sales channel, and the app writes it to `public.sc` and re-stamps the cart with it (backward compatible). | An organization with no `salesChannel` configured is **not** defaulted: the app skips the `public.sc` write and the cart re-stamp entirely, leaving the sales channel to whatever already set it (e.g. the binding). |
+
+Only the merchant can turn this on in the VTEX Admin (App settings). It has no effect for organizations that **do** have a `salesChannel` configured — those keep being written as before, on or off.
+
+## 3. Logic flow (what the code does)
+
+- `setProfile` loads the organization, cost center, sales channels, marketing tags, B2B settings, and **app settings** in parallel (app settings are cached in memory, see [Cost center address and region § 6](COST_CENTER_ADDRESS_AND_REGION.md#6-caching-app-settings) for the caching pattern).
+- `hasOrgSalesChannel` = the organization has a non-empty `salesChannel`.
+- `deferSalesChannelToBinding` = `!hasOrgSalesChannel && appSettings.deferSalesChannelToBinding`.
+- If `deferSalesChannelToBinding` is **false**: unchanged behavior — when the organization's `salesChannel` is empty or not an active sales channel, it falls back to the account's first active sales channel.
+- If `deferSalesChannelToBinding` is **true**: the fallback is skipped, so `salesChannel` stays empty; the app does **not** call `checkout.updateSalesChannel` and does **not** write `public.sc`.
+- **Region lookup is independent:** a separate `regionLookupSalesChannel` (the resolved `salesChannel`, or the first active sales channel if none) is used only for the `checkout.getRegionId` call, so deferring the session/cart write never leaves the region lookup without a sales channel.
+
+## 4. Summary table
+
+| Scenario | `public.sc` | Cart re-stamp | Region lookup |
+|----------|-------------|----------------|----------------|
+| Org has a valid `salesChannel` | Written | Yes | Uses the org's sales channel |
+| Org has no `salesChannel`, flag **off** | Written (first active sales channel) | Yes | Uses the first active sales channel |
+| Org has no `salesChannel`, flag **on** | **Not written** (deferred) | **No** | Uses the first active sales channel (independent fallback) |
+
+## 5. Related configuration
+
+- **Session:** `vtex.session/configuration.json` declares `public.sc` as an output of the `storefront-permissions` transform — the same shared field `vtex.binding-selector` writes to when restamping the cart for a binding change.
+- **App settings:** `manifest.json` `settingsSchema` defines **Defer sales channel to binding** (boolean, default `false`).
+- **Binding selector:** [`vtex.binding-selector`](https://github.com/vtex-apps/binding-selector) restamps the checkout order form's sales channel (`updateSalesChannel` → `POST /orderForm/{id}/items?sc={salesChannel}`) when the shopper changes binding. Enable `deferSalesChannelToBinding` when this app is installed and organizations are intentionally left without a `salesChannel` so the binding stays the source of truth.

--- a/docs/SALES_CHANNEL_BINDING_COEXISTENCE.md
+++ b/docs/SALES_CHANNEL_BINDING_COEXISTENCE.md
@@ -12,7 +12,7 @@ In stores that also use bindings to serve multiple locales/sales channels (`vtex
 
 | Field | Description |
 |-------|-------------|
-| `public.sc` | The resolved sales channel. Left untouched (no write) when the organization has no `salesChannel` and `deferSalesChannelToBinding` is on — see below. |
+| `public.sc` | The resolved sales channel. Omitted from the `setProfile` response entirely (not sent even as an empty value) when the organization has no `salesChannel` and `deferSalesChannelToBinding` is on, so the session merge leaves it as whatever already set it — see below. |
 | `public.regionId` | Unaffected by this setting: region lookup uses its own independent sales-channel fallback so it always has a value to query with, even when the session's `sc` write is deferred. |
 
 This is part of the same `setProfile` output already declared in `vtex.session/configuration.json` (`public.sc`); no new session input/output field was added.
@@ -31,7 +31,7 @@ Only the merchant can turn this on in the VTEX Admin (App settings). It has no e
 - `hasOrgSalesChannel` = the organization has a non-empty `salesChannel`.
 - `deferSalesChannelToBinding` = `!hasOrgSalesChannel && appSettings.deferSalesChannelToBinding`.
 - If `deferSalesChannelToBinding` is **false**: unchanged behavior — when the organization's `salesChannel` is empty or not an active sales channel, it falls back to the account's first active sales channel.
-- If `deferSalesChannelToBinding` is **true**: the fallback is skipped, so `salesChannel` stays empty; the app does **not** call `checkout.updateSalesChannel` and does **not** write `public.sc`.
+- If `deferSalesChannelToBinding` is **true**: the fallback is skipped, so `salesChannel` stays empty; the app does **not** call `checkout.updateSalesChannel`, and it **deletes** `public.sc` from the response instead of sending `{ value: '' }` — an explicit empty value is treated as a real write during session merge elsewhere in this app (e.g. the `regionId` case), so leaving the key in would have cleared whatever already set the sales channel.
 - **Region lookup is independent:** a separate `regionLookupSalesChannel` (the resolved `salesChannel`, or the first active sales channel if none) is used only for the `checkout.getRegionId` call, so deferring the session/cart write never leaves the region lookup without a sales channel.
 
 ## 4. Summary table

--- a/manifest.json
+++ b/manifest.json
@@ -156,6 +156,12 @@
         "description": "When enabled, the session accepts allowRegionOverwrite from the frontend. When sent and both public.postalCode and public.country are set, we set public.regionId to empty and do not update the cart with an address; checkout-session backend then sets checkout.regionId from those values. Only the merchant can enable this (app setting).",
         "type": "boolean",
         "default": false
+      },
+      "deferSalesChannelToBinding": {
+        "title": "Defer sales channel to binding",
+        "description": "When enabled, if the organization has no salesChannel set, this app does not patch the session's public.sc or restamp the cart's sales channel, leaving that value to whatever already set it (e.g. vtex.binding-selector). When disabled, an organization with no salesChannel set falls back to the account's first active sales channel (backward compatible).",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -526,6 +526,8 @@ export const Routes = {
 
     let { salesChannel } = organization
 
+    const hasOrgSalesChannel = !!salesChannel?.length
+
     const salesChannelsData =
       (salesChannels as unknown as { data?: any[] })?.data ?? []
 
@@ -533,17 +535,30 @@ export const Routes = {
       (channel: any) => channel.IsActive
     )
 
+    const deferSalesChannelToBinding =
+      !hasOrgSalesChannel && !!(appSettings as any)?.deferSalesChannelToBinding
+
+    // When the organization has no salesChannel of its own, defaulting it here
+    // races with other apps (e.g. vtex.binding-selector) that also patch the
+    // session/cart sales channel from the chosen binding. If the merchant opted
+    // in, skip that default entirely and let the binding be the source of truth.
     if (
-      !salesChannel?.length ||
-      !validChannels?.find(
-        (validSalesChannel: any) =>
-          String(validSalesChannel.Id) === salesChannel.toString()
-      )
+      !deferSalesChannelToBinding &&
+      (!salesChannel?.length ||
+        !validChannels?.find(
+          (validSalesChannel: any) =>
+            String(validSalesChannel.Id) === salesChannel.toString()
+        ))
     ) {
       if (validChannels.length) {
         salesChannel = validChannels[0].Id
       }
     }
+
+    // Only used for the region lookup below; falls back independently of
+    // deferSalesChannelToBinding since it doesn't write to the shared session/cart.
+    const regionLookupSalesChannel =
+      salesChannel || (validChannels.length ? validChannels[0].Id : null)
 
     const salesChannelPromise = []
 
@@ -559,6 +574,11 @@ export const Routes = {
           })
       )
       response.public.sc.value = salesChannel.toString()
+    } else if (deferSalesChannelToBinding) {
+      logger.info({
+        message: 'setProfile.salesChannelDeferredToBinding',
+        orgId: user.orgId,
+      })
     }
 
     if (hashChanged && orderFormId) {
@@ -587,12 +607,12 @@ export const Routes = {
       const marketingTags: any = (marketingTagsResponse as any)?.data
         ?.getMarketingTags?.tags
 
-      if (!usePublicPostalCodeForRegion) {
+      if (!usePublicPostalCodeForRegion && regionLookupSalesChannel) {
         try {
           const [regionId] = await checkout.getRegionId(
             address.country,
             address.postalCode,
-            salesChannel.toString(),
+            regionLookupSalesChannel.toString(),
             address.geoCoordinates
           )
 
@@ -611,7 +631,9 @@ export const Routes = {
         response.public.regionId = { value: '' }
         logger.info({
           message: 'setProfile.regionIdSkipped',
-          reason: 'usePublicPostalCodeForRegion',
+          reason: usePublicPostalCodeForRegion
+            ? 'usePublicPostalCodeForRegion'
+            : 'noSalesChannelAvailable',
           publicPostalCode: body?.public?.postalCode?.value ?? null,
         })
       }

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -297,9 +297,9 @@ export const Routes = {
 
     // in case the cost center is not found, we need to find a valid cost center for the user
     if (
-      Object.values(
-        costCenterResponse.data?.getCostCenterById ?? {}
-      ).every((value) => value === null)
+      Object.values(costCenterResponse.data?.getCostCenterById ?? {}).every(
+        (value) => value === null
+      )
     ) {
       try {
         const usersByEmail = await organizations.getOrganizationsByEmail(email)
@@ -412,12 +412,14 @@ export const Routes = {
     }
 
     const orgSellers = organization.sellers
-    const costCenterSellers = costCenterResponse?.data?.getCostCenterById?.sellers
+    const costCenterSellers =
+      costCenterResponse?.data?.getCostCenterById?.sellers
+
     const sellersArray = Array.isArray(costCenterSellers)
       ? costCenterSellers
       : Array.isArray(orgSellers)
-        ? orgSellers
-        : []
+      ? orgSellers
+      : []
 
     if (sellersArray.length > 0) {
       const sellersList = sellersArray
@@ -449,6 +451,7 @@ export const Routes = {
 
     response['storefront-permissions'].costcenter.value = user.costId
     const costCenterData = costCenterResponse?.data?.getCostCenterById
+
     phoneNumber = costCenterData?.phoneNumber
 
     businessDocument =
@@ -458,26 +461,32 @@ export const Routes = {
 
     const costCenterAddresses =
       (costCenterData as { addresses?: any[] } | undefined)?.addresses ?? []
+
     const enableCostCenterAddressSelection =
       (appSettings as any)?.enableCostCenterAddressSelection ?? false
+
     const enableRegionOverwriteFlag =
       (appSettings as any)?.enableRegionOverwrite ?? false
-    const publicCostCenterAddressId =
-      body?.public?.costCenterAddressId?.value
+
+    const publicCostCenterAddressId = body?.public?.costCenterAddressId?.value
     const requestedAddressId = enableCostCenterAddressSelection
       ? publicCostCenterAddressId
       : undefined
+
     const explicitlyClearedCostCenterAddress =
       enableCostCenterAddressSelection &&
       (publicCostCenterAddressId === '' || publicCostCenterAddressId === null)
+
     const allowRegionOverwrite =
       enableRegionOverwriteFlag && !!body?.public?.allowRegionOverwrite?.value
+
     const hasPublicPostalCode = !!body?.public?.postalCode?.value
     const hasPublicCountry = !!body?.public?.country?.value
     const usePublicPostalCodeForRegion =
       allowRegionOverwrite && hasPublicPostalCode && hasPublicCountry
 
     let selectedAddress: any = null
+
     if (costCenterAddresses.length) {
       if (requestedAddressId) {
         selectedAddress = costCenterAddresses.find(
@@ -494,8 +503,11 @@ export const Routes = {
       } else {
         selectedAddress = costCenterAddresses[0]
       }
+
       response['storefront-permissions'].costCenterAddressId.value =
-        explicitlyClearedCostCenterAddress ? '' : (selectedAddress?.addressId ?? '')
+        explicitlyClearedCostCenterAddress
+          ? ''
+          : selectedAddress?.addressId ?? ''
     } else {
       // No cost center addresses: per docs, costCenterAddressId should be empty
       response['storefront-permissions'].costCenterAddressId.value = ''
@@ -516,6 +528,7 @@ export const Routes = {
 
     const salesChannelsData =
       (salesChannels as unknown as { data?: any[] })?.data ?? []
+
     const validChannels = salesChannelsData.filter(
       (channel: any) => channel.IsActive
     )
@@ -571,8 +584,8 @@ export const Routes = {
     // checkout-session will use public.postalCode and public.country for checkout.regionId. We also do not update the cart with an address.
     if (selectedAddress && orderFormId) {
       const address = selectedAddress
-      const marketingTags: any =
-        (marketingTagsResponse as any)?.data?.getMarketingTags?.tags
+      const marketingTags: any = (marketingTagsResponse as any)?.data
+        ?.getMarketingTags?.tags
 
       if (!usePublicPostalCodeForRegion) {
         try {
@@ -669,7 +682,9 @@ export const Routes = {
             documentType: documentType ?? undefined,
             phone: phoneNumberFormatted,
             stateInscription:
-              (stateRegistration ?? clUser.stateInscription ?? '0'.repeat(9)) ??
+              stateRegistration ??
+              clUser.stateInscription ??
+              '0'.repeat(9) ??
               null,
           })
           .catch((error) => {

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -575,6 +575,11 @@ export const Routes = {
       )
       response.public.sc.value = salesChannel.toString()
     } else if (deferSalesChannelToBinding) {
+      // Omit `sc` entirely rather than sending `{ value: '' }`: this app treats
+      // an explicit empty value as a real write during session merge (see the
+      // regionId case below), so leaving the key in would clear whatever
+      // already set the session's sales channel (e.g. the binding).
+      delete response.public.sc
       logger.info({
         message: 'setProfile.salesChannelDeferredToBinding',
         orgId: user.orgId,


### PR DESCRIPTION
## Summary

`storefront-permissions` patches the VTEX session's `public.sc` (and re-stamps the checkout orderForm's sales channel) using the organization's `salesChannel`, falling back to the account's first active sales channel whenever the organization has none set. This runs unconditionally on every `setProfile` session-transform call, with no awareness of other apps.

`vtex.binding-selector` also sets the sales channel based on the shopper's chosen binding, restamping the cart the same way. Since both apps write to the same shared `public.sc` session field from independent triggers, with no precedence, **whichever one writes last wins** — the storefront can look correct after switching bindings, but checkout/cart retains the wrong sales channel context. This is the reported root cause for Kohler and other multi-binding B2B implementations.

- New app setting `deferSalesChannelToBinding` (default `false`, backward compatible).
- When enabled **and** the organization has no `salesChannel` configured, `setProfile` skips defaulting/writing the sales channel to the session and skips re-stamping the cart, leaving the binding (or whatever already set it) as the source of truth.
- When the organization *does* have a valid `salesChannel`, or the flag is off, behavior is unchanged.
- Region lookup (`checkout.getRegionId`) keeps its own independent fallback (`regionLookupSalesChannel`) since it only affects this app's own `regionId` output, not the shared `sc` field — so deferring never leaves that call without a sales channel to query with.

## Context

- Jira: [B2BTEAM-3593](https://vtex-dev.atlassian.net/browse/B2BTEAM-3593)
- Root cause confirmed against `vtex-apps/binding-selector` (its own SC restamp via `updateSalesChannel`/`addItems`) and the engineering discussion in Slack (Mateus Saggin's analysis: "storefront-permissions also writes the sales channel via its Session App... both apps write SC into the session from different triggers with no precedence, so the last writer wins").

## Test plan

- [ ] Merchant with `deferSalesChannelToBinding` off (default): confirm behavior is unchanged — org with no SC still falls back to first active sales channel.
- [ ] Merchant with `deferSalesChannelToBinding` on, org with no SC configured, `vtex.binding-selector` installed: switch bindings and confirm checkout keeps the binding's sales channel instead of being overwritten by SFP.
- [ ] Merchant with `deferSalesChannelToBinding` on, org **with** a valid SC configured: confirm SFP still writes/enforces the org's SC as before.

[B2BTEAM-3593]: https://vtex-dev.atlassian.net/browse/B2BTEAM-3593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ