### PR TITLE
fix: scope checkUserPermission to impersonated profile during impersonation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .qodo
+.cursor
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `checkUserPermission` no longer returns the union of the acting Operator's and impersonated profile's permissions during Call Center impersonation sessions. It now scopes the result to the impersonated profile only, preventing the Operator's elevated permissions from leaking into the storefront. [B2BTEAM-3566]
+
 ## [3.5.0] - 2026-07-15
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "storefront-permissions",
   "vendor": "vtex",
-  "version": "3.5.0",
+  "version": "3.5.1-beta.0",
   "title": "Storefront Permissions",
   "description": "Manage User's permissions on apps that relates to this app",
   "mustUpdateAt": "2022-08-28",

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -679,34 +679,18 @@ export const checkUserPermission = async (
 
   const module = removeVersionFromAppId(sender)
 
-  const authPermissions = await getRoleAndPermissionsByEmail({
+  // During impersonation (authEmail !== profileEmail), permissions must be
+  // scoped to the impersonated profile only, never the acting Operator's.
+  const isImpersonating = Boolean(profileEmail) && authEmail !== profileEmail
+
+  const targetEmail = isImpersonating ? profileEmail : authEmail
+
+  return getRoleAndPermissionsByEmail({
     ctx,
-    email: authEmail,
+    email: targetEmail,
     module,
     skipError: true,
   })
-
-  const profilePermissions =
-    profileEmail && authEmail !== profileEmail
-      ? await getRoleAndPermissionsByEmail({
-          ctx,
-          email: profileEmail,
-          module,
-          skipError: true,
-        })
-      : defaultResponse
-
-  return {
-    permissions: [
-      ...new Set([
-        ...authPermissions.permissions,
-        ...profilePermissions.permissions,
-      ]),
-    ],
-    role: authPermissions.role.id
-      ? authPermissions.role
-      : profilePermissions.role,
-  }
 }
 
 export const checkImpersonation = async (_: any, __: any, ctx: Context) => {


### PR DESCRIPTION
**What problem is this solving?**

`checkUserPermission` handles the "two identities" scenario (Call Center Operator impersonating a customer via `vtex.telemarketing`) by fetching permissions for both the Operator (`authentication.storeUserEmail`) and the impersonated profile (`profile.email`), then returning the **deduplicated union** whenever the two differ (logic from [#39](https://github.com/vtex-apps/storefront-permissions/pull/39)).

This lets the Operator's elevated permissions leak into the impersonated storefront session, which can produce incorrect access/gating decisions in storefront apps that treat this query as the source of truth for the current profile's permissions. Flagged as a security issue by a partner (Kohler), confirmed by the team as unintended behavior — see [B2BTEAM-3566](https://vtex-dev.atlassian.net/browse/B2BTEAM-3566).

**Fix**

Scope `checkUserPermission` to a single identity:
- During impersonation (`profile.email` present and different from `authentication.storeUserEmail`), return only the impersonated profile's permissions.
- Otherwise, return the authenticated user's permissions as before.

The `UserPermissions { role, permissions }` response shape is unchanged — this is a behavioral fix, not a schema/contract change. Consumers that happened to rely on the leaked union (none identified as intentional) will see reduced permissions during impersonation, as intended.

**How should this be manually tested?**

1. Set up a Call Center Operator (`vtex.telemarketing`) session impersonating a customer profile with different (fewer) permissions than the Operator.
2. Call `checkUserPermission` as that sender/module.
3. Confirm the response reflects only the impersonated profile's role/permissions, not a union with the Operator's.
4. Confirm normal (non-impersonated) sessions are unaffected.

**Screenshots or example usage:**

N/A (backend GraphQL resolver change)

Ref: B2BTEAM-3566

[B2BTEAM-3566]: https://vtex-dev.atlassian.net/browse/B2BTEAM-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ