### PR TITLE
feat: add strictImpersonationPermissions setting for checkUserPermission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New app setting `strictImpersonationPermissions` (default `false`) controlling how `checkUserPermission` evaluates impersonation sessions. When enabled, only the impersonated profile's permissions are returned, so the acting user's permissions never leak into the storefront. When disabled, the acting user's and the impersonated profile's permissions are aggregated. [B2BTEAM-3566]
+- Documentation: `checkUserPermission` now documents its contract during impersonation sessions, for both the `vtex.telemarketing` and the B2B Organizations impersonation flows. [B2BTEAM-3566]
+
+### Changed
+
+- **Reverts the 3.5.1 default.** Aggregated permissions during impersonation are the default again, because 3.5.1 made strict scoping unconditional and that silently removes permissions the default B2B Suite configuration depends on - `can-checkout` is not granted to the `customer-buyer` role, so a sales representative impersonating an Organization Buyer could no longer complete checkout. Stores that want the strict behavior of 3.5.1 must now enable `strictImpersonationPermissions`. [B2BTEAM-3566]
+
 ## [3.6.0] - 2026-07-31
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -183,6 +183,24 @@ Sample response:
 }
 ```
 
+##### Behavior during impersonation
+
+An impersonation session has two identities: the **acting user** (the Operator, sales representative or approver who started the session, kept in `authentication.storeUserEmail`) and the **impersonated profile** (kept in the `profile` namespace). This applies to both impersonation flows: `vtex.telemarketing` and the [B2B Organizations](https://developers.vtex.com/vtex-developer-docs/docs/vtex-b2b-organizations#impersonate-users) app.
+
+Which identity `checkUserPermission` evaluates is controlled by the `strictImpersonationPermissions` app setting:
+
+| Setting | Result during impersonation |
+|---|---|
+| `false` (default) | The deduplicated **union** of the acting user's and the impersonated profile's permissions. `role` is the acting user's role, falling back to the impersonated profile's role when the acting user has none. |
+| `true` | **Only** the impersonated profile's permissions and role. The acting user's permissions are never returned. |
+
+Outside impersonation sessions both modes behave identically, returning the authenticated user's permissions.
+
+Pick the mode that matches your store:
+
+- Enable `strictImpersonationPermissions` when the storefront must render exactly what the impersonated user is allowed to do, and elevated permissions from the acting user would produce incorrect gating.
+- Keep it disabled when a flow depends on the acting user's rights while impersonating. Note that some of these flows exist in the default B2B Suite configuration: `can-checkout` is not granted to the `customer-buyer` role, so a sales representative impersonating an Organization Buyer relies on aggregation to complete the purchase. Review your role configuration before enabling strict mode.
+
 
 
 #### hasUsers

--- a/manifest.json
+++ b/manifest.json
@@ -162,6 +162,12 @@
         "description": "When enabled, if the organization has no salesChannel set, this app does not patch the session's public.sc or restamp the cart's sales channel, leaving that value to whatever already set it (e.g. vtex.binding-selector). When disabled, an organization with no salesChannel set falls back to the account's first active sales channel (backward compatible).",
         "type": "boolean",
         "default": false
+      },
+      "strictImpersonationPermissions": {
+        "title": "Strict impersonation permissions",
+        "description": "When enabled, checkUserPermission returns only the impersonated profile's permissions during an impersonation session, so the acting user's (Operator, sales representative, approver) permissions never leak into the storefront. When disabled (default), the permissions of the acting user and the impersonated profile are aggregated, which is required by flows that rely on the acting user's rights while impersonating - for example a sales representative completing checkout for a buyer role that has no can-checkout permission, or an approver retaining approval power.",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { removeVersionFromAppId } from '@vtex/api'
 
+import { getCachedAppSettings } from '../../services/appSettingsCache'
 import type { GetOrganizationsPaginatedByEmailResponse } from '../../typings/custom'
 import { currentSchema } from '../../utils'
 import {
@@ -679,18 +680,70 @@ export const checkUserPermission = async (
 
   const module = removeVersionFromAppId(sender)
 
-  // During impersonation (authEmail !== profileEmail), permissions must be
-  // scoped to the impersonated profile only, never the acting Operator's.
+  // Both impersonation flows (vtex.telemarketing and the Organizations app)
+  // switch the profile namespace to the impersonated user while
+  // authentication.storeUserEmail keeps holding the acting user, so a
+  // divergence between the two is what identifies an impersonation session.
   const isImpersonating = Boolean(profileEmail) && authEmail !== profileEmail
 
-  const targetEmail = isImpersonating ? profileEmail : authEmail
+  if (!isImpersonating) {
+    return getRoleAndPermissionsByEmail({
+      ctx,
+      email: authEmail,
+      module,
+      skipError: true,
+    })
+  }
 
-  return getRoleAndPermissionsByEmail({
-    ctx,
-    email: targetEmail,
-    module,
-    skipError: true,
+  // Only impersonation sessions need the setting, so regular sessions never
+  // pay for reading it (cached for 5 minutes when they do).
+  const appSettings = await getCachedAppSettings(ctx).catch((error) => {
+    logger.warn({ error, message: 'checkUserPermission-getAppSettingsError' })
+
+    return {} as Record<string, unknown>
   })
+
+  // Strict mode: scope the evaluation to the impersonated profile so the
+  // acting user's elevated permissions never reach the storefront.
+  if ((appSettings as any)?.strictImpersonationPermissions) {
+    return getRoleAndPermissionsByEmail({
+      ctx,
+      email: profileEmail,
+      module,
+      skipError: true,
+    })
+  }
+
+  // Aggregated mode (default): keep the legacy union, which flows relying on
+  // the acting user's rights while impersonating depend on - for example a
+  // sales representative completing checkout for a buyer role that has no
+  // can-checkout permission, or an approver retaining approval power.
+  const [authPermissions, profilePermissions] = await Promise.all([
+    getRoleAndPermissionsByEmail({
+      ctx,
+      email: authEmail,
+      module,
+      skipError: true,
+    }),
+    getRoleAndPermissionsByEmail({
+      ctx,
+      email: profileEmail,
+      module,
+      skipError: true,
+    }),
+  ])
+
+  return {
+    permissions: [
+      ...new Set([
+        ...authPermissions.permissions,
+        ...profilePermissions.permissions,
+      ]),
+    ],
+    role: authPermissions.role.id
+      ? authPermissions.role
+      : profilePermissions.role,
+  }
 }
 
 export const checkImpersonation = async (_: any, __: any, ctx: Context) => {


### PR DESCRIPTION
**What problem is this solving?**

In version `3.5.1`, `checkUserPermission` started scoping permissions to the impersonated profile unconditionally. That prevents the acting user's permissions from reaching the storefront during impersonation, but it also removes permissions that the default B2B Suite configuration relies on:

- `can-checkout` is granted to `store-admin`, `sales-admin`, `sales-manager`, `sales-representative`, `customer-admin` and `customer-approver`, but not to `customer-buyer`.
- Aggregation is therefore what allows a sales representative impersonating an Organization Buyer to complete a purchase, a capability described for sales roles in `docs/README.md`.
- With strict scoping always on, that checkout stops working.

Both behaviors are legitimate depending on the store: some need the storefront to render exactly what the impersonated user can do, others depend on the acting user's rights during impersonation (for example approval flows).

This also affects both impersonation flows, not only `vtex.telemarketing`. The B2B Organizations app switches the profile namespace through `storefront-permissions.storeUserId`, which `vtex.profile-session` takes as an input, so `authentication.storeUserEmail` and `profile.email` diverge in both flows.

**What changed**

The behavior is now controlled by a new app setting:

| `strictImpersonationPermissions` | Result during impersonation |
|---|---|
| `true` | Only the impersonated profile's permissions and role (the `3.5.1` behavior). |
| `false` (**default**) | Deduplicated union of the acting user's and the impersonated profile's permissions; `role` prefers the acting user's, falling back to the impersonated profile's (the `3.5.0` behavior). |

Sessions outside impersonation are unchanged in both modes.

This restores the `3.5.0` default on purpose. Apps auto-update within a major, so keeping strict scoping on by default would continue to remove `can-checkout` in stores that did not opt into the change. Stores that want strict scoping enable the setting. Flipping the default to strict is a candidate for the next major, with a migration note.

Notes for reviewers:

- The aggregated branch reproduces the pre-`3.5.1` semantics exactly, including the `role` fallback order.
- App settings are read only for impersonation sessions, through the existing 5-minute LRU cache (`getCachedAppSettings`), so regular sessions are not affected. A settings read failure logs a warning and falls back to the default (aggregated) mode.
- `UserPermissions { role, permissions }` is unchanged, so there is no GraphQL schema change.
- Documents the query's behavior during impersonation in `docs/README.md`, which was previously unspecified.

**How should this be manually tested?**

With the setting disabled (default):

1. As a `sales-representative`, impersonate a `customer-buyer` through the B2B Organizations app.
2. Confirm `checkUserPermission` returns the union of both sets, that `can-checkout` is present, and that checkout completes.

With `strictImpersonationPermissions` enabled in the app settings:

3. Repeat the impersonation and confirm `checkUserPermission` returns only the buyer's role and permissions, with no permission coming from the sales representative.
4. Repeat the check for a `vtex.telemarketing` session impersonating a customer.
5. In both modes, confirm that a regular (non-impersonated) login is unaffected.

**Screenshots or example usage:**

N/A (backend resolver and app setting)

Ref: B2BTEAM-3566
