### PR TITLE
Added request chain priority; added conditional debug

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,9 @@
   "root": true,
   "env": {
     "node": true
+  },
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
+    "max-params": "off"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .qodo
 .cursor
 .claude
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `setProfile` no longer blocks the session response on cart/profile side effects (`clearCart`, `getB2BSettings`, `getMarketingTags`, `updateOrderFormShipping`, `updateOrderFormMarketingData`, `generateClUser`, `updateOrderFormProfile`). These only affect the cart/profile, not the session's own fields, so they now run in a detached chain after the response is sent — reducing `setProfile`'s response time and its exposure to `session-manager`'s 2s timeout on the transform call. Internal ordering (`clearCart` before the writes that follow it) is unchanged.
+
+### Added
+
+- New app setting `debug` (default `false`) to enable `setProfile` timing logs. When enabled, each `setProfile.timing` log includes `orderFormId` and the accumulated step timeline.
+
 ## [3.6.3] - 2026-08-19
 
 ## [3.6.2] - 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - `setProfile` no longer blocks the session response on cart/profile side effects (`clearCart`, `getB2BSettings`, `getMarketingTags`, `updateOrderFormShipping`, `updateOrderFormMarketingData`, `generateClUser`, `updateOrderFormProfile`). These only affect the cart/profile, not the session's own fields, so they now run in a detached chain after the response is sent — reducing `setProfile`'s response time and its exposure to `session-manager`'s 2s timeout on the transform call. Internal ordering (`clearCart` before the writes that follow it) is unchanged.
+- `setProfile` reads cost centers from Master Data (`cost_centers`) via `masterDataExtended` instead of `b2b-organizations-graphql`. `getActiveUserByEmail` now searches `b2b_users` through the same client instead of paginating with the default Master Data client. Invalid-cost-center and inactive-organization fallbacks (`getOrganizationsByEmail` / `getOrganizationsPaginatedByEmail`) now search `b2b_users` and hydrate `cost_centers` / `organizations` the same way, instead of the GraphQL round-trip through `b2b-organizations-graphql`.
+- `masterDataExtended` HTTP GETs (`getDocumentById`, `searchDocuments`) are cached in-process for 30 minutes, keyed per request URL so distinct documents/searches do not share a slot.
 
 ### Added
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,8 @@ For B2B session behavior related to **cost center address selection** and **regi
 
 For B2B session behavior related to **sales channel coexistence with binding selection** (multi-binding stores using `vtex.binding-selector`), see [Sales channel coexistence with binding selection](SALES_CHANNEL_BINDING_COEXISTENCE.md).
 
+For **app settings** (`deferSalesChannelToBinding`, `debug`) and the **in-process caches** used by `setProfile`, see [App settings and caching](#app-settings-and-caching).
+
 The **Storefront Permissions** app does not contain an interface – it operates “backstage”, storing the predefined roles and serving as a bridge to communicate with other apps in order to check user permissions. If you would like to manage roles and app permissions using the VTEX Admin interface, you must also install the [Storefront Permissions UI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-storefront-permissions-ui) app. As an optional feature, you can install the [Admin Customers](https://developers.vtex.com/vtex-developer-docs/docs/vtex-admin-customers) app for additional customer management capabilities.
 
 
@@ -54,6 +56,45 @@ If you opt to develop your own app and [integrate](#advanced-app-integration-opt
 ## Installation
 
 You can install the app by running `vtex install vtex.storefront-permissions` in your terminal, using the [VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference).
+
+
+## App settings and caching
+
+Settings are configured in the VTEX Admin under the **Storefront Permissions** app. Only the merchant can change them; the storefront cannot turn these flags on by itself. App-settings reads are cached for 5 minutes, so a change in Admin can take up to that TTL to affect `setProfile`.
+
+### `deferSalesChannelToBinding`
+
+Default: `false`.
+
+`setProfile` always uses the organization's `salesChannel` when it is set and matches an active channel. This flag only changes the **fallback** when the organization has **no** `salesChannel`:
+
+| Flag | Organization has `salesChannel` | Organization has no `salesChannel` |
+|---|---|---|
+| **Off** (default) | Writes that channel to `public.sc` and restamps the cart. | Falls back to the account's first active sales channel, writes `public.sc`, and restamps the cart. |
+| **On** | Unchanged: still writes the org channel to `public.sc` and restamps the cart. | Does **not** default the channel. Omits `public.sc` from the session response (does not send an empty value, which would clear whatever already set it) and skips `checkout.updateSalesChannel`. The binding (for example `vtex.binding-selector`) stays the source of truth. |
+
+Region lookup is independent of this flag: if the session/cart write is deferred, `getRegionId` still uses the first active sales channel so region resolution is not left without a channel.
+
+Enable this in multi-binding stores where organizations are intentionally left without a `salesChannel` and another app sets `sc` from the chosen binding. Full flow: [Sales channel coexistence with binding selection](SALES_CHANNEL_BINDING_COEXISTENCE.md).
+
+### `debug`
+
+Default: `false`. Keep it off except while diagnosing session latency.
+
+When **on**, `setProfile` emits `setProfile.timing` logs (`logger.debug`) with `orderFormId` and the accumulated step timeline (`stepMs` / `durationMs`, `totalMs`). When **off**, those logs are skipped; the session work still runs. This does not change session fields, cart updates, or cache behavior.
+
+### Caching
+
+`setProfile` uses **in-process LRU** caches (per IO isolate: not shared across replicas, cleared on cold start). HTTP client cache is keyed by request URL, so distinct documents or searches occupy distinct slots — fetching organization `1` and then `2` stores two entries; the next fetch of `1` returns only `1`.
+
+| Cache | TTL | Key | What it stores |
+|---|---|---|---|
+| App settings | 5 minutes | `{account}-{workspace}-{appId}` | Manifest settings (`debug`, `deferSalesChannelToBinding`, and the other flags). |
+| Sales channel list | 12 hours | HTTP GET `/api/catalog_system/pvt/saleschannel/list` | Account sales-channel list used to validate/fallback `sc` and for region lookup. |
+| Master Data (`masterDataExtended`) | 30 minutes | HTTP GET URL (`/documents/{id}` or `/search?...`) | Organization and cost-center documents, plus `b2b_users` searches (`getActiveUserByEmail` and invalid-org/cost-center fallbacks). |
+| User-organizations fallback | 5 minutes | `orgs-{email}` | Result of the invalid cost center / inactive organization fallback for that email. |
+
+Writes to Master Data (for example changing an organization's sales channel or the user's active profile) can take up to the corresponding TTL to show up in `setProfile` on that isolate. For the app-settings cache pattern, see also [Cost center address and region § 6](COST_CENTER_ADDRESS_AND_REGION.md#6-caching-app-settings).
 
 
 ## Advanced app integration [optional]

--- a/manifest.json
+++ b/manifest.json
@@ -168,6 +168,12 @@
         "description": "When enabled, checkUserPermission returns only the impersonated profile's permissions during an impersonation session, so the acting user's (Operator, sales representative, approver) permissions never leak into the storefront. When disabled (default), the permissions of the acting user and the impersonated profile are aggregated, which is required by flows that rely on the acting user's rights while impersonating - for example a sales representative completing checkout for a buyer role that has no can-checkout permission, or an approver retaining approval power.",
         "type": "boolean",
         "default": false
+      },
+      "debug": {
+        "title": "Enable setProfile debug logs",
+        "description": "When enabled, setProfile emits detailed timing logs (setProfile.timing) including orderFormId and step durations. Keep disabled unless diagnosing session latency.",
+        "type": "boolean",
+        "default": false
       }
     }
   },

--- a/node/clients/Organizations.ts
+++ b/node/clients/Organizations.ts
@@ -1,13 +1,8 @@
-import type { GraphQLResponse, InstanceOptions, IOContext } from '@vtex/api'
+import type { InstanceOptions, IOContext } from '@vtex/api'
 import { AppGraphQLClient } from '@vtex/api'
 
 import { QUERIES } from '../resolvers/Routes/utils'
 import { getTokenToHeader } from './index'
-import type {
-  GetCostCenterType,
-  GetOrganizationsByEmailResponse,
-  GetOrganizationsPaginatedByEmailResponse,
-} from '../typings/custom'
 
 const getPersistedQuery = () => {
   return {
@@ -41,16 +36,6 @@ export class OrganizationsGraphQLClient extends AppGraphQLClient {
     })
   }
 
-  public getCostCenterById = async (costId: string) => {
-    return this.query({
-      extensions: getPersistedQuery(),
-      query: QUERIES.getCostCenterById,
-      variables: {
-        id: costId,
-      },
-    }) as Promise<GraphQLResponse<GetCostCenterType>>
-  }
-
   public getMarketingTags = async (costId: string): Promise<unknown> => {
     return this.query({
       extensions: getPersistedQuery(),
@@ -59,34 +44,6 @@ export class OrganizationsGraphQLClient extends AppGraphQLClient {
         costId,
       },
     })
-  }
-
-  public getOrganizationsByEmail = async (email: string) => {
-    return this.query({
-      extensions: getPersistedQuery(),
-      query: QUERIES.getOrganizationsByEmail,
-      variables: { email },
-    }) as Promise<GetOrganizationsByEmailResponse>
-  }
-
-  public getOrganizationsPaginatedByEmail = async (
-    email: string,
-    page: number,
-    pageSize: number
-  ) => {
-    return this.query({
-      extensions: getPersistedQuery(),
-      query: QUERIES.getOrganizationsPaginatedByEmail,
-      variables: {
-        email,
-        page,
-        pageSize,
-      },
-    }) as Promise<{
-      data: {
-        getOrganizationsPaginatedByEmail: GetOrganizationsPaginatedByEmailResponse
-      }
-    }>
   }
 
   private query = async (param: {

--- a/node/clients/masterDataExtended.ts
+++ b/node/clients/masterDataExtended.ts
@@ -6,6 +6,8 @@ import { JanusClient } from '@vtex/api'
   to calling Master Data directly from the app using this custom client.
 */
 
+export const MASTERDATA_EXTENDED_CACHE_MAX_AGE_MS = 30 * 60 * 1000
+
 export class MasterDataExtended extends JanusClient {
   constructor(context: IOContext, options?: InstanceOptions) {
     super(context, {
@@ -24,6 +26,57 @@ export class MasterDataExtended extends JanusClient {
     this.http.get(
       `/api/dataentities/${dataEntity}/documents/${id}?_fields=${fields.join(
         ','
-      )}`
+      )}`,
+      {
+        forceMaxAge: MASTERDATA_EXTENDED_CACHE_MAX_AGE_MS,
+        metric: 'masterdata-get-document',
+      }
     )
+
+  public searchDocuments = <T = unknown>(params: {
+    dataEntity: string
+    fields: string[]
+    where?: string
+    schema?: string
+    sort?: string
+    pagination?: { page: number; pageSize: number }
+  }) => {
+    const {
+      dataEntity,
+      fields,
+      where,
+      schema,
+      sort,
+      pagination = { page: 1, pageSize: 50 },
+    } = params
+
+    const from = (pagination.page - 1) * pagination.pageSize
+    const to = from + pagination.pageSize - 1
+    const query = new URLSearchParams({
+      _fields: fields.join(','),
+    })
+
+    if (where) {
+      query.set('_where', where)
+    }
+
+    if (schema) {
+      query.set('_schema', schema)
+    }
+
+    if (sort) {
+      query.set('_sort', sort)
+    }
+
+    return this.http.get<T[]>(
+      `/api/dataentities/${dataEntity}/search?${query.toString()}`,
+      {
+        forceMaxAge: MASTERDATA_EXTENDED_CACHE_MAX_AGE_MS,
+        headers: {
+          'REST-Range': `resources=${from}-${to}`,
+        },
+        metric: 'masterdata-search',
+      }
+    )
+  }
 }

--- a/node/clients/salesChannel.ts
+++ b/node/clients/salesChannel.ts
@@ -10,6 +10,8 @@ export interface SalesChannelResponse {
   CultureInfo: string
 }
 
+export const SALES_CHANNEL_CACHE_MAX_AGE_MS = 12 * 60 * 60 * 1000
+
 export class SalesChannel extends JanusClient {
   constructor(context: IOContext, options?: InstanceOptions) {
     super(context, {
@@ -21,8 +23,12 @@ export class SalesChannel extends JanusClient {
   }
 
   public getSalesChannel = async () => ({
-    data: await this.http.get<SalesChannelResponse>(
-      '/api/catalog_system/pvt/saleschannel/list'
+    data: await this.http.get<SalesChannelResponse[]>(
+      '/api/catalog_system/pvt/saleschannel/list',
+      {
+        forceMaxAge: SALES_CHANNEL_CACHE_MAX_AGE_MS,
+        metric: 'get-sales-channel',
+      }
     ),
   })
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -12,6 +12,8 @@ import { method, Service, AuthType, LRUCache } from '@vtex/api'
 
 import { schemaDirectives } from './directives'
 import { Clients } from './clients'
+import { MASTERDATA_EXTENDED_CACHE_MAX_AGE_MS } from './clients/masterDataExtended'
+import { SALES_CHANNEL_CACHE_MAX_AGE_MS } from './clients/salesChannel'
 import { resolvers } from './resolvers'
 
 const TIMEOUT_MS = 5000
@@ -23,6 +25,16 @@ const defaultClientOptions = {
 
 const memoryCache = new LRUCache<string, any>({ max: 1000 })
 
+const salesChannelCache = new LRUCache<string, any>({
+  max: 1000,
+  maxAge: SALES_CHANNEL_CACHE_MAX_AGE_MS,
+})
+
+const masterDataExtendedCache = new LRUCache<string, any>({
+  max: 1000,
+  maxAge: MASTERDATA_EXTENDED_CACHE_MAX_AGE_MS,
+})
+
 const clients: ClientsConfig<Clients> = {
   implementation: Clients,
   options: {
@@ -33,6 +45,12 @@ const clients: ClientsConfig<Clients> = {
     b2bAdmin: {
       authType: AuthType.bearer,
       memoryCache,
+    },
+    salesChannel: {
+      memoryCache: salesChannelCache,
+    },
+    masterDataExtended: {
+      memoryCache: masterDataExtendedCache,
     },
   },
 }

--- a/node/resolvers/Mutations/Users.ts
+++ b/node/resolvers/Mutations/Users.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { currentSchema } from '../../utils'
-import { CUSTOMER_SCHEMA_NAME } from '../../utils/constants'
+import {
+  COST_CENTER_DATA_ENTITY,
+  COST_CENTER_FIELDS,
+  CUSTOMER_SCHEMA_NAME,
+} from '../../utils/constants'
 import type { ChangeTeamParams } from '../../utils/metrics/changeTeam'
 import { sendChangeTeamMetric } from '../../utils/metrics/changeTeam'
 import {
@@ -237,17 +241,18 @@ export const addUser = async (_: any, params: any, ctx: Context) => {
   } = ctx
 
   try {
-    const costCenter = await ctx.clients.organizations.getCostCenterById(
-      params.costId
-    )
+    const costCenter: any = await ctx.clients.masterDataExtended
+      .getDocumentById(
+        COST_CENTER_DATA_ENTITY,
+        params.costId,
+        COST_CENTER_FIELDS
+      )
+      .catch(() => null)
 
     // before adding an user to a cost center we check if the cost
     // center exists and if it has a valid name, otherwise both
     // login and UI might break.
-    if (
-      !costCenter?.data?.getCostCenterById?.name ||
-      params.orgId !== costCenter?.data?.getCostCenterById?.organization
-    ) {
+    if (!costCenter?.name || params.orgId !== costCenter?.organization) {
       throw new Error(`Invalid cost center`)
     }
 

--- a/node/resolvers/Queries/Users.ts
+++ b/node/resolvers/Queries/Users.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-params */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { removeVersionFromAppId } from '@vtex/api'
 
@@ -12,6 +13,19 @@ import GraphQLError from '../../utils/GraphQLError'
 import { getRole } from './Roles'
 
 const config: any = currentSchema('b2b_users')
+
+const B2B_USER_FIELDS = [
+  'id',
+  'roleId',
+  'clId',
+  'email',
+  'name',
+  'orgId',
+  'costId',
+  'userId',
+  'canImpersonate',
+  'active',
+]
 
 const PAGINATION = {
   page: 1,
@@ -125,7 +139,7 @@ export const getAllUsers = async ({
       error,
       message: 'Profiles.getAllUsersByEmail-error',
     })
-    throw new Error(error)
+    throw new Error(error instanceof Error ? error.message : String(error))
   }
 }
 
@@ -156,14 +170,33 @@ export const getActiveUserByEmail = async (
   ctx: Context
 ) => {
   const {
+    clients: { masterDataExtended },
     vtex: { logger },
   } = ctx
 
-  try {
-    const users = await getAllUsersByEmail(null, params, ctx)
-    const activeUser = users.find((user: any) => user.active)
+  const { email, orgId, costId } = params
 
-    const userFound = activeUser || users[0]
+  let where = `email=${email}`
+
+  if (orgId) {
+    where += ` AND orgId=${orgId}`
+  }
+
+  if (costId) {
+    where += ` AND costId=${costId}`
+  }
+
+  try {
+    const users = await masterDataExtended.searchDocuments<any>({
+      dataEntity: config.name,
+      fields: B2B_USER_FIELDS,
+      pagination: { page: 1, pageSize: 50 },
+      schema: config.version,
+      sort: 'active DESC',
+      where,
+    })
+
+    const userFound = users?.find((user: any) => user.active) ?? users?.[0]
 
     if (!userFound) {
       logger.warn({
@@ -841,7 +874,7 @@ export const getUsersByEmail = async (_: any, params: any, ctx: Context) => {
       error,
       message: `getUsersByEmail-error`,
     })
-    throw new Error(error)
+    throw new Error(error instanceof Error ? error.message : String(error))
   }
 }
 
@@ -911,7 +944,7 @@ export const getOrganizationsPaginatedByEmail = async (
       message: 'getOrganizationsPaginatedByEmail-error',
     })
 
-    throw new Error(error)
+    throw new Error(error instanceof Error ? error.message : String(error))
   }
 }
 
@@ -966,6 +999,6 @@ export const getUserByEmailOrgIdAndCostId = async (
       error,
       message: `getUsersByEmail-error`,
     })
-    throw new Error(error)
+    throw new Error(error instanceof Error ? error.message : String(error))
   }
 }

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -2,6 +2,13 @@ import { ForbiddenError } from '@vtex/api'
 import { json } from 'co-body'
 
 import { getCachedAppSettings } from '../../services/appSettingsCache'
+import { toHash } from '../../utils'
+import {
+  COST_CENTER_DATA_ENTITY,
+  COST_CENTER_FIELDS,
+  ORGANIZATION_DATA_ENTITY,
+  ORGANIZATION_FIELDS,
+} from '../../utils/constants'
 import { getRole } from '../Queries/Roles'
 import { getSessionWatcher } from '../Queries/Settings'
 import { generateClUser, getUserOrganizationsData } from './utils'
@@ -11,7 +18,6 @@ import {
   getB2BUserById,
 } from '../Queries/Users'
 import { getUser, setActiveUserByOrganization } from '../Mutations/Users'
-import { toHash } from '../../utils'
 
 type SetProfileStepTiming = {
   durationMs?: number
@@ -405,15 +411,7 @@ export const Routes = {
 
     const getOrganization = async (orgId: any): Promise<any> => {
       return masterDataExtended
-        .getDocumentById('organizations', orgId, [
-          'name',
-          'tradeName',
-          'status',
-          'priceTables',
-          'salesChannel',
-          'collections',
-          'sellers',
-        ])
+        .getDocumentById(ORGANIZATION_DATA_ENTITY, orgId, ORGANIZATION_FIELDS)
         .catch((error) => {
           logger.error({
             error,
@@ -432,7 +430,22 @@ export const Routes = {
         timedSetProfile('getOrganization', getOrganization(user.orgId)),
         timedSetProfile(
           'getCostCenterById',
-          organizations.getCostCenterById(user.costId)
+          masterDataExtended
+            .getDocumentById(
+              COST_CENTER_DATA_ENTITY,
+              user.costId,
+              COST_CENTER_FIELDS
+            )
+            .catch((error) => {
+              if (error?.response?.status !== 404) {
+                logger.error({
+                  error,
+                  message: 'setProfile.getCostCenterById',
+                })
+              }
+
+              return {}
+            })
         ),
         timedSetProfile(
           'getSalesChannel',
@@ -442,41 +455,13 @@ export const Routes = {
 
     logSetProfileStep('parallel.organizationCostCenterSettings')
 
-    // in case the cost center is not found, we need to find a valid cost center for the user
-    if (
-      Object.values(costCenterResponse.data?.getCostCenterById ?? {}).every(
-        (value) => value === null
-      )
-    ) {
-      try {
-        const usersByEmail = await timedSetProfile(
-          'getOrganizationsByEmail',
-          organizations.getOrganizationsByEmail(email)
-        )
-
-        // when cost center comes without a name, it's because the cost center is deleted
-        const usersData = usersByEmail.data.getOrganizationsByEmail.find(
-          (userByEmail) => userByEmail.costCenterName !== null
-        )
-
-        user.costId = usersData?.costId ?? user.costId
-      } catch (error) {
-        logger.error({
-          error,
-          message: 'setProfile.graphqlGetOrganizationById',
-        })
-      }
-
-      logSetProfileStep('fallback.invalidCostCenter')
-    }
-
     let organization: any = organizationResponse
     let userOrgsData: any = null
 
     // Check if we need to fetch user organizations (for inactive org or invalid cost center)
-    const costCenterInvalid = Object.values(
-      costCenterResponse.data?.getCostCenterById ?? {}
-    ).every((value) => value === null)
+    const costCenterInvalid = Object.values(costCenterResponse ?? {}).every(
+      (value) => value === null
+    )
 
     const organizationInactive = organization.status === 'inactive'
     const needsOrgData = organizationInactive || costCenterInvalid
@@ -497,6 +482,7 @@ export const Routes = {
     }
 
     // Handle invalid cost center first
+    // when cost center comes without a name, it's because the cost center is deleted
     if (costCenterInvalid && userOrgsData?.validCostCenterId) {
       user.costId = userOrgsData.validCostCenterId
     }
@@ -506,12 +492,10 @@ export const Routes = {
       const validOrganization = userOrgsData?.activeOrganization
 
       if (validOrganization) {
-        organization = (
-          await timedSetProfile(
-            'getOrganization.inactiveFallback',
-            getOrganization(validOrganization.id)
-          )
-        )?.data?.getOrganizationById
+        organization = await timedSetProfile(
+          'getOrganization.inactiveFallback',
+          getOrganization(validOrganization.orgId)
+        )
 
         await timedSetProfile(
           'setActiveUserByOrganization',
@@ -574,8 +558,7 @@ export const Routes = {
     }
 
     const orgSellers = organization.sellers
-    const costCenterSellers =
-      costCenterResponse?.data?.getCostCenterById?.sellers
+    const costCenterSellers = costCenterResponse?.sellers
 
     const sellersArray = Array.isArray(costCenterSellers)
       ? costCenterSellers
@@ -613,7 +596,7 @@ export const Routes = {
     logSetProfileStep('resolveFacets')
 
     response['storefront-permissions'].costcenter.value = user.costId
-    const costCenterData = costCenterResponse?.data?.getCostCenterById
+    const costCenterData = costCenterResponse
 
     phoneNumber = costCenterData?.phoneNumber
 

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -21,11 +21,35 @@ type SetProfileStepTiming = {
   totalMs: number
 }
 
-const createSetProfileTimers = (logger: Context['vtex']['logger']) => {
+type SetProfileLogContext = {
+  debug: boolean
+  orderFormId?: string
+}
+
+const createSetProfileTimers = (
+  logger: Context['vtex']['logger'],
+  logContext: SetProfileLogContext
+) => {
   const timing = { prev: Date.now(), t0: Date.now() }
   const steps: SetProfileStepTiming[] = []
 
+  const emitTiming = (payload: Record<string, unknown>) => {
+    if (!logContext.debug) {
+      return
+    }
+
+    logger.debug({
+      message: 'setProfile.timing',
+      orderFormId: logContext.orderFormId,
+      ...payload,
+    })
+  }
+
   const logSetProfileStep = (step: string, extra?: Record<string, unknown>) => {
+    if (!logContext.debug) {
+      return
+    }
+
     const now = Date.now()
     const stepTiming: SetProfileStepTiming = {
       step,
@@ -36,8 +60,7 @@ const createSetProfileTimers = (logger: Context['vtex']['logger']) => {
     steps.push(stepTiming)
     timing.prev = now
 
-    logger.debug({
-      message: 'setProfile.timing',
+    emitTiming({
       step,
       stepMs: stepTiming.stepMs,
       totalMs: stepTiming.totalMs,
@@ -50,6 +73,10 @@ const createSetProfileTimers = (logger: Context['vtex']['logger']) => {
     step: string,
     promise: Promise<T>
   ): Promise<T> => {
+    if (!logContext.debug) {
+      return promise
+    }
+
     const start = Date.now()
 
     try {
@@ -63,8 +90,7 @@ const createSetProfileTimers = (logger: Context['vtex']['logger']) => {
 
       steps.push(stepTiming)
 
-      logger.debug({
-        message: 'setProfile.timing',
+      emitTiming({
         step,
         durationMs: stepTiming.durationMs,
         totalMs: stepTiming.totalMs,
@@ -83,8 +109,7 @@ const createSetProfileTimers = (logger: Context['vtex']['logger']) => {
 
       steps.push(stepTiming)
 
-      logger.debug({
-        message: 'setProfile.timing',
+      emitTiming({
         step,
         durationMs: stepTiming.durationMs,
         failed: true,
@@ -192,10 +217,11 @@ export const Routes = {
       vtex: { logger },
     } = ctx
 
-    const { logSetProfileStep, timedSetProfile } =
-      createSetProfileTimers(logger)
+    const appSettingsPromise = getCachedAppSettings(ctx).catch((error) => {
+      logger.warn({ error, message: 'setProfile.getAppSettingsError' })
 
-    logSetProfileStep('start')
+      return {} as Record<string, unknown>
+    })
 
     const response: any = {
       public: {
@@ -240,6 +266,18 @@ export const Routes = {
     ctx.set('Content-Type', 'application/json')
     ctx.set('Cache-Control', 'no-cache, no-store')
 
+    const appSettings = await appSettingsPromise
+    const logContext: SetProfileLogContext = {
+      debug: appSettings.debug === true,
+    }
+
+    const { logSetProfileStep, timedSetProfile } = createSetProfileTimers(
+      logger,
+      logContext
+    )
+
+    logSetProfileStep('start')
+
     const isWatchActive = await timedSetProfile(
       'getSessionWatcher',
       getSessionWatcher(null, null, ctx)
@@ -255,7 +293,6 @@ export const Routes = {
       return
     }
 
-    const promises = [] as Array<Promise<any>>
     const body: any = await timedSetProfile('parseBody', json(req))
 
     logSetProfileStep('parseBody')
@@ -263,6 +300,8 @@ export const Routes = {
     const b2bImpersonate = body?.public?.impersonate?.value
     const telemarketingImpersonate = body?.impersonate?.storeUserId?.value
     const orderFormId = body?.checkout?.orderFormId?.value
+
+    logContext.orderFormId = orderFormId
     const isCorporate = true
 
     let email = body?.authentication?.storeUserEmail?.value
@@ -388,27 +427,18 @@ export const Routes = {
 
     response['storefront-permissions'].hash.value = hash
 
-    const [
-      organizationResponse,
-      costCenterResponse,
-      salesChannels,
-      marketingTagsResponse,
-      b2bSettingsResponse,
-      appSettings,
-    ] = await Promise.all([
-      timedSetProfile('getOrganization', getOrganization(user.orgId)),
-      timedSetProfile(
-        'getCostCenterById',
-        organizations.getCostCenterById(user.costId)
-      ),
-      timedSetProfile('getSalesChannel', salesChannelClient.getSalesChannel()),
-      timedSetProfile(
-        'getMarketingTags',
-        organizations.getMarketingTags(user.costId)
-      ),
-      timedSetProfile('getB2BSettings', organizations.getB2BSettings()),
-      timedSetProfile('getCachedAppSettings', getCachedAppSettings(ctx)),
-    ])
+    const [organizationResponse, costCenterResponse, salesChannels] =
+      await Promise.all([
+        timedSetProfile('getOrganization', getOrganization(user.orgId)),
+        timedSetProfile(
+          'getCostCenterById',
+          organizations.getCostCenterById(user.costId)
+        ),
+        timedSetProfile(
+          'getSalesChannel',
+          salesChannelClient.getSalesChannel()
+        ),
+      ])
 
     logSetProfileStep('parallel.organizationCostCenterSettings')
 
@@ -695,22 +725,7 @@ export const Routes = {
 
     logSetProfileStep('resolveAddressAndSalesChannel')
 
-    const salesChannelPromise = []
-
     if (salesChannel) {
-      salesChannelPromise.push(
-        timedSetProfile(
-          'updateSalesChannel',
-          checkout
-            .updateSalesChannel(orderFormId, salesChannel)
-            .catch((error) => {
-              logger.error({
-                error,
-                message: 'setProfile.updateSalesChannel',
-              })
-            })
-        )
-      )
       response.public.sc.value = salesChannel.toString()
     } else if (deferSalesChannelToBinding) {
       // Omit `sc` entirely rather than sending `{ value: '' }`: this app treats
@@ -724,185 +739,230 @@ export const Routes = {
       })
     }
 
-    if (hashChanged && orderFormId) {
+    // regionId is part of the session response, so it has to be resolved
+    // before we answer — everything else below this block only affects the
+    // cart/profile, not this response, and is deferred past ctx.response.body.
+    //
+    // When usePublicPostalCodeForRegion (overwrite on + public.postalCode and public.country set): we do not set public.regionId and we set it to empty;
+    // checkout-session will use public.postalCode and public.country for checkout.regionId. We also do not update the cart with an address.
+    if (
+      selectedAddress &&
+      orderFormId &&
+      !usePublicPostalCodeForRegion &&
+      regionLookupSalesChannel
+    ) {
       try {
-        const b2bSettings = (b2bSettingsResponse as any)?.data?.getB2BSettings
-        const {
-          uiSettings: { clearCart },
-        } = b2bSettings ?? { uiSettings: { clearCart: null } }
-
-        if (clearCart) {
-          await timedSetProfile(
-            'updateSalesChannel.beforeClearCart',
-            Promise.all(salesChannelPromise)
+        const [regionId] = await timedSetProfile(
+          'getRegionId',
+          checkout.getRegionId(
+            selectedAddress.country,
+            selectedAddress.postalCode,
+            regionLookupSalesChannel.toString(),
+            selectedAddress.geoCoordinates
           )
-          await timedSetProfile('clearCart', checkout.clearCart(orderFormId))
+        )
+
+        if (regionId?.id) {
+          response.public.regionId = {
+            value: regionId.id,
+          }
         }
+
+        logSetProfileStep('getRegionId')
       } catch (error) {
         logger.error({
           error,
-          message: 'setProfile.clearCart',
+          message: 'setProfile.getRegionId',
         })
+        logSetProfileStep('getRegionId.error')
       }
-
-      logSetProfileStep('clearCart')
-    }
-
-    // When usePublicPostalCodeForRegion (overwrite on + public.postalCode and public.country set): we do not set public.regionId and we set it to empty;
-    // checkout-session will use public.postalCode and public.country for checkout.regionId. We also do not update the cart with an address.
-    if (selectedAddress && orderFormId) {
-      const address = selectedAddress
-      const marketingTags: any = (marketingTagsResponse as any)?.data
-        ?.getMarketingTags?.tags
-
-      if (!usePublicPostalCodeForRegion && regionLookupSalesChannel) {
-        try {
-          const [regionId] = await timedSetProfile(
-            'getRegionId',
-            checkout.getRegionId(
-              address.country,
-              address.postalCode,
-              regionLookupSalesChannel.toString(),
-              address.geoCoordinates
-            )
-          )
-
-          if (regionId?.id) {
-            response.public.regionId = {
-              value: regionId.id,
-            }
-          }
-
-          logSetProfileStep('getRegionId')
-        } catch (error) {
-          logger.error({
-            error,
-            message: 'setProfile.getRegionId',
-          })
-          logSetProfileStep('getRegionId.error')
-        }
-      } else {
-        response.public.regionId = { value: '' }
-        logger.info({
-          message: 'setProfile.regionIdSkipped',
-          reason: usePublicPostalCodeForRegion
-            ? 'usePublicPostalCodeForRegion'
-            : 'noSalesChannelAvailable',
-          publicPostalCode: body?.public?.postalCode?.value ?? null,
-        })
-      }
-
-      promises.push(
-        timedSetProfile(
-          'updateOrderFormMarketingData',
-          checkout
-            .updateOrderFormMarketingData(orderFormId, {
-              attachmentId: 'marketingData',
-              marketingTags: marketingTags || [],
-              utmCampaign: user.orgId,
-              utmMedium: user.costId,
-            })
-            .catch((error) => {
-              logger.error({
-                error,
-                message: 'setProfile.updateOrderFormMarketingDataError',
-              })
-            })
-        )
-      )
-
-      if (!usePublicPostalCodeForRegion) {
-        promises.push(
-          timedSetProfile(
-            'updateOrderFormShipping',
-            checkout
-              .updateOrderFormShipping(orderFormId, {
-                address: {
-                  ...address,
-                  geoCoordinates: address.geoCoordinates ?? [],
-                  isDisposable: true,
-                },
-                clearAddressIfPostalCodeNotFound: false,
-              })
-              .catch((error) => {
-                logger.error({
-                  error,
-                  message: 'setProfile.updateOrderFormShippingError',
-                })
-              })
-          )
-        )
-      } else {
-        logger.info({
-          message: 'setProfile.cartShippingSkipped',
-          reason: 'usePublicPostalCodeForRegion',
-        })
-      }
-    }
-
-    const clUser = await timedSetProfile(
-      'generateClUser',
-      generateClUser({
-        businessDocument,
-        businessName,
-        clId: user?.clId ?? '',
-        ctx,
-        phoneNumber: phoneNumber ?? null,
-        stateRegistration,
-        tradeName,
-        isCorporate,
+    } else {
+      response.public.regionId = { value: '' }
+      logger.info({
+        message: 'setProfile.regionIdSkipped',
+        reason: usePublicPostalCodeForRegion
+          ? 'usePublicPostalCodeForRegion'
+          : 'noSalesChannelAvailable',
+        publicPostalCode: body?.public?.postalCode?.value ?? null,
       })
-    )
-
-    logSetProfileStep('generateClUser')
-
-    if (clUser && orderFormId) {
-      const phoneNumberFormatted =
-        phoneNumber || clUser.phone || clUser.homePhone || `+1${'0'.repeat(10)}`
-
-      promises.push(
-        timedSetProfile(
-          'updateOrderFormProfile',
-          checkout
-            .updateOrderFormProfile(orderFormId, {
-              ...clUser,
-              businessDocument:
-                (businessDocument || clUser.businessDocument) ?? null,
-              documentType: documentType ?? undefined,
-              phone: phoneNumberFormatted,
-              stateInscription:
-                stateRegistration ??
-                clUser.stateInscription ??
-                '0'.repeat(9) ??
-                null,
-            })
-            .catch((error) => {
-              logger.error({
-                error,
-                message: 'setProfile.updateOrderFormProfileError',
-              })
-            })
-        )
-      )
     }
-
-    // Don't await promises, to avoid session timeout
-    Promise.all(promises)
 
     logSetProfileStep('done', {
       email,
       orgId: user?.orgId,
       costId: user?.costId,
       orderFormId,
-      deferredPromises: promises.length,
     })
 
     logger.info({
       'setProfile.body': JSON.stringify(body),
       'setProfile.output': JSON.stringify(response),
+      orderFormId,
     })
 
     ctx.response.body = response
     ctx.response.status = 200
+
+    // --- Nothing below this line blocks the session response. ---
+    // These calls only affect the cart/profile, never the setProfile output,
+    // so they run as a detached chain after the response has already been
+    // sent. clearCart still has to happen before the shipping/marketing
+    // writes that follow it, or it would wipe them straight back out — that
+    // ordering is preserved *inside* this chain, it's just off the response's
+    // critical path now.
+    ;(async () => {
+      try {
+        if (salesChannel) {
+          await timedSetProfile(
+            'updateSalesChannel',
+            checkout
+              .updateSalesChannel(orderFormId, salesChannel)
+              .catch((error) => {
+                logger.error({
+                  error,
+                  message: 'setProfile.updateSalesChannel',
+                })
+              })
+          )
+        }
+
+        if (hashChanged && orderFormId) {
+          try {
+            const [b2bSettingsResponse, marketingTagsResponse] =
+              await Promise.all([
+                timedSetProfile(
+                  'getB2BSettings',
+                  organizations.getB2BSettings()
+                ),
+                timedSetProfile(
+                  'getMarketingTags',
+                  organizations.getMarketingTags(user.costId)
+                ),
+              ])
+
+            const b2bSettings = (b2bSettingsResponse as any)?.data
+              ?.getB2BSettings
+
+            const {
+              uiSettings: { clearCart },
+            } = b2bSettings ?? { uiSettings: { clearCart: null } }
+
+            if (clearCart) {
+              await timedSetProfile(
+                'clearCart',
+                checkout.clearCart(orderFormId)
+              )
+            }
+
+            if (selectedAddress && orderFormId) {
+              const marketingTags: any = (marketingTagsResponse as any)?.data
+                ?.getMarketingTags?.tags
+
+              await timedSetProfile(
+                'updateOrderFormMarketingData',
+                checkout
+                  .updateOrderFormMarketingData(orderFormId, {
+                    attachmentId: 'marketingData',
+                    marketingTags: marketingTags || [],
+                    utmCampaign: user.orgId,
+                    utmMedium: user.costId,
+                  })
+                  .catch((error) => {
+                    logger.error({
+                      error,
+                      message: 'setProfile.updateOrderFormMarketingDataError',
+                    })
+                  })
+              )
+
+              if (!usePublicPostalCodeForRegion) {
+                await timedSetProfile(
+                  'updateOrderFormShipping',
+                  checkout
+                    .updateOrderFormShipping(orderFormId, {
+                      address: {
+                        ...selectedAddress,
+                        geoCoordinates: selectedAddress.geoCoordinates ?? [],
+                        isDisposable: true,
+                      },
+                      clearAddressIfPostalCodeNotFound: false,
+                    })
+                    .catch((error) => {
+                      logger.error({
+                        error,
+                        message: 'setProfile.updateOrderFormShippingError',
+                      })
+                    })
+                )
+              } else {
+                logger.info({
+                  message: 'setProfile.cartShippingSkipped',
+                  reason: 'usePublicPostalCodeForRegion',
+                })
+              }
+            }
+          } catch (error) {
+            logger.error({
+              error,
+              message: 'setProfile.clearCart',
+            })
+          }
+
+          logSetProfileStep('clearCart')
+        }
+
+        const clUser = await timedSetProfile(
+          'generateClUser',
+          generateClUser({
+            businessDocument,
+            businessName,
+            clId: user?.clId ?? '',
+            ctx,
+            phoneNumber: phoneNumber ?? null,
+            stateRegistration,
+            tradeName,
+            isCorporate,
+          })
+        )
+
+        logSetProfileStep('generateClUser')
+
+        if (clUser && orderFormId) {
+          const phoneNumberFormatted =
+            phoneNumber ||
+            clUser.phone ||
+            clUser.homePhone ||
+            `+1${'0'.repeat(10)}`
+
+          await timedSetProfile(
+            'updateOrderFormProfile',
+            checkout
+              .updateOrderFormProfile(orderFormId, {
+                ...clUser,
+                businessDocument:
+                  (businessDocument || clUser.businessDocument) ?? null,
+                documentType: documentType ?? undefined,
+                phone: phoneNumberFormatted,
+                stateInscription:
+                  stateRegistration ??
+                  clUser.stateInscription ??
+                  '0'.repeat(9) ??
+                  null,
+              })
+              .catch((error) => {
+                logger.error({
+                  error,
+                  message: 'setProfile.updateOrderFormProfileError',
+                })
+              })
+          )
+        }
+      } catch (error) {
+        logger.error({
+          error,
+          message: 'setProfile.deferredPostResponse',
+        })
+      }
+    })()
   },
 }

--- a/node/resolvers/Routes/utils/index.ts
+++ b/node/resolvers/Routes/utils/index.ts
@@ -1,5 +1,18 @@
 import type { GetOrganizationByEmailBase } from '../../../typings/custom'
+import { currentSchema } from '../../../utils'
+import {
+  COST_CENTER_DATA_ENTITY,
+  ORGANIZATION_DATA_ENTITY,
+} from '../../../utils/constants'
 import { getUserById } from '../../Queries/Users'
+
+const B2B_USERS_SCHEMA: { name: string; version: string } = currentSchema(
+  'b2b_users'
+) as any
+
+const USER_ORG_FIELDS = ['id', 'orgId', 'costId']
+const MD_SEARCH_PAGE_SIZE = 100
+const MD_SEARCH_MAX_PAGES = 5
 
 // Simple in-memory cache with TTL
 const organizationsCache = new Map<string, { data: any; timestamp: number }>()
@@ -20,39 +33,6 @@ export const QUERIES = {
         }
       }
   }`,
-  getCostCenterById: `query Costcenter($id: ID!) {
-      getCostCenterById(id: $id) {
-        paymentTerms {
-          id
-          name
-        }
-        name
-        organization
-        addresses {
-          addressId
-          addressType
-          addressQuery
-          postalCode
-          country
-          receiverName
-          city
-          state
-          street
-          number
-          complement
-          neighborhood
-          geoCoordinates
-          reference
-        }
-        phoneNumber
-        businessDocument
-        stateRegistration
-        sellers {
-          id
-          name
-        }
-      }
-    }`,
   getMarketingTags: `
     query ($costId: ID!) {
       getMarketingTags(costId: $costId){
@@ -76,35 +56,6 @@ export const QUERIES = {
         }
       }
     }`,
-  getOrganizationsByEmail: `query Organizations($email: String!) {
-       getOrganizationsByEmail(email: $email){
-          id
-          organizationStatus
-          costId
-          orgId
-          costCenterName
-       }
-  }`,
-  getOrganizationsPaginatedByEmail: `query OrganizationsPaginated($email: String!, $page: Int, $pageSize: Int) {
-    getOrganizationsPaginatedByEmail(
-      email: $email
-      page: $page
-      pageSize: $pageSize
-    ) {
-      data {
-        id
-        organizationStatus
-        costId
-        orgId
-        costCenterName
-      }
-      pagination {
-        page
-        pageSize
-        total
-      }
-    }
-  }`,
 }
 
 export const generateClUser = async ({
@@ -168,6 +119,170 @@ export const generateClUser = async ({
   return clUser
 }
 
+type UserOrgProfile = {
+  id: string
+  orgId: string
+  costId: string
+}
+
+const getDocumentOrNull = async <T>(
+  getDocument: () => Promise<T>,
+  logger: Context['vtex']['logger'],
+  message: string
+): Promise<T | null> => {
+  try {
+    return await getDocument()
+  } catch (error) {
+    if ((error as ErrorResponse)?.response?.status !== 404) {
+      logger.error({ error, message })
+    }
+
+    return null
+  }
+}
+
+const toUserOrgRow = (
+  user: UserOrgProfile,
+  costCenterNames: Map<string, string | null>,
+  organizationStatuses: Map<string, string | null>
+): GetOrganizationByEmailBase => ({
+  id: user.id,
+  orgId: user.orgId,
+  costId: user.costId,
+  costCenterName: costCenterNames.get(user.costId) ?? null,
+  organizationStatus: organizationStatuses.get(user.orgId) ?? '',
+})
+
+/**
+ * Lists the caller's `b2b_users` profiles for an email and hydrates
+ * `costCenterName` / `organizationStatus` from Master Data (`cost_centers`,
+ * `organizations`). Replaces the GraphQL hop through
+ * `b2b-organizations-graphql` (which called back into this app).
+ */
+export const listUserOrganizationsByEmail = async (
+  email: string,
+  ctx: Context
+): Promise<GetOrganizationByEmailBase[]> => {
+  const {
+    clients: { masterDataExtended },
+    vtex: { logger },
+  } = ctx
+
+  const costCenterNames = new Map<string, string | null>()
+  const organizationStatuses = new Map<string, string | null>()
+  const users: UserOrgProfile[] = []
+
+  const hydrateNewIds = async (batch: UserOrgProfile[]) => {
+    const newCostIds = [
+      ...new Set(
+        batch
+          .map((user) => user.costId)
+          .filter((id) => id && !costCenterNames.has(id))
+      ),
+    ]
+
+    const newOrgIds = [
+      ...new Set(
+        batch
+          .map((user) => user.orgId)
+          .filter((id) => id && !organizationStatuses.has(id))
+      ),
+    ]
+
+    await Promise.all([
+      ...newCostIds.map(async (id) => {
+        const costCenter: { name?: string | null } | null =
+          await getDocumentOrNull(
+            () =>
+              masterDataExtended.getDocumentById(COST_CENTER_DATA_ENTITY, id, [
+                'id',
+                'name',
+              ]),
+            logger,
+            'listUserOrganizationsByEmail.getCostCenter'
+          )
+
+        costCenterNames.set(id, costCenter ? costCenter.name ?? null : null)
+      }),
+      ...newOrgIds.map(async (id) => {
+        const organization: { status?: string | null } | null =
+          await getDocumentOrNull(
+            () =>
+              masterDataExtended.getDocumentById(ORGANIZATION_DATA_ENTITY, id, [
+                'id',
+                'status',
+              ]),
+            logger,
+            'listUserOrganizationsByEmail.getOrganization'
+          )
+
+        organizationStatuses.set(
+          id,
+          organization ? organization.status ?? null : null
+        )
+      }),
+    ])
+  }
+
+  const searchPage = (page: number) =>
+    masterDataExtended.searchDocuments<UserOrgProfile>({
+      dataEntity: B2B_USERS_SCHEMA.name,
+      fields: USER_ORG_FIELDS,
+      pagination: { page, pageSize: MD_SEARCH_PAGE_SIZE },
+      schema: B2B_USERS_SCHEMA.version,
+      where: `email=${email}`,
+    })
+
+  const firstPage = await searchPage(1)
+
+  if (!firstPage?.length) {
+    return []
+  }
+
+  users.push(...firstPage)
+  await hydrateNewIds(firstPage)
+
+  const hasValidCostCenter = users.some(
+    (user) => (costCenterNames.get(user.costId) ?? null) !== null
+  )
+
+  const hasActiveOrg = users.some(
+    (user) => organizationStatuses.get(user.orgId) !== 'inactive'
+  )
+
+  if (
+    firstPage.length === MD_SEARCH_PAGE_SIZE &&
+    (!hasValidCostCenter || !hasActiveOrg)
+  ) {
+    const remainingPages = Array.from(
+      { length: MD_SEARCH_MAX_PAGES - 1 },
+      (_, i) => i + 2
+    )
+
+    const additionalBatches = await Promise.all(
+      remainingPages.map((page) =>
+        searchPage(page).catch((error) => {
+          logger.warn({ error, message: 'Failed to fetch page', page })
+
+          return [] as UserOrgProfile[]
+        })
+      )
+    )
+
+    const extraUsers = additionalBatches.reduce(
+      (acc, batch) => acc.concat(batch),
+      [] as UserOrgProfile[]
+    )
+
+    users.push(...extraUsers)
+    await hydrateNewIds(extraUsers)
+  }
+
+  return users.map((user) =>
+    toUserOrgRow(user, costCenterNames, organizationStatuses)
+  )
+}
+
 /**
  * Unified method to get user organizations data with caching.
  * Fetches all organizations for an email and returns relevant data for different validations.
@@ -199,72 +314,13 @@ export const getUserOrganizationsData = async (
     }
   }
 
-  const { organizations } = ctx.clients
   const {
     vtex: { logger },
   } = ctx
 
   try {
-    const firstResponse = await organizations.getOrganizationsPaginatedByEmail(
-      email,
-      1,
-      200 // Most users have < 200 orgs, this usually gets everything in one call
-    )
+    const allOrganizations = await listUserOrganizationsByEmail(email, ctx)
 
-    const { data: firstPageData, pagination } =
-      firstResponse?.data?.getOrganizationsPaginatedByEmail || {}
-
-    if (!firstPageData?.length) {
-      return { validCostCenterId: null, activeOrganization: null }
-    }
-
-    const allOrganizations = [...firstPageData]
-
-    // Only paginate if there are more pages and we haven't found both values
-    const totalPages = Math.ceil((pagination?.total || 0) / 200)
-
-    if (totalPages > 1) {
-      // Check if we already have what we need from first page
-      const hasValidCostCenter = firstPageData.some(
-        (org) => org.costCenterName !== null
-      )
-
-      const hasActiveOrg = firstPageData.some(
-        (org) => org.organizationStatus !== 'inactive'
-      )
-
-      // Only fetch more pages if we're missing data
-      if (!hasValidCostCenter || !hasActiveOrg) {
-        // Fetch remaining pages in parallel for better performance
-        const remainingPages = Array.from(
-          { length: Math.min(totalPages - 1, 4) }, // Limit to 5 total pages max
-          (_, i) => i + 2
-        )
-
-        const additionalResponses = await Promise.all(
-          remainingPages.map((page) =>
-            organizations
-              .getOrganizationsPaginatedByEmail(email, page, 200)
-              .catch((error) => {
-                logger.warn({ error, message: 'Failed to fetch page', page })
-
-                return null
-              })
-          )
-        )
-
-        // Combine all results
-        for (const response of additionalResponses) {
-          if (response?.data?.getOrganizationsPaginatedByEmail?.data) {
-            allOrganizations.push(
-              ...response.data.getOrganizationsPaginatedByEmail.data
-            )
-          }
-        }
-      }
-    }
-
-    // Find required values from all organizations
     const validCostCenterOrg = allOrganizations.find(
       (org) => org.costCenterName !== null
     )
@@ -274,8 +330,8 @@ export const getUserOrganizationsData = async (
     )
 
     const result = {
-      validCostCenterId: validCostCenterOrg?.costId || null,
-      activeOrganization: activeOrg || null,
+      validCostCenterId: validCostCenterOrg?.costId ?? null,
+      activeOrganization: activeOrg ?? null,
     }
 
     // Cache the result

--- a/node/services/appSettingsCache.ts
+++ b/node/services/appSettingsCache.ts
@@ -12,11 +12,12 @@ const settingsCache = new LRUCache<string, Record<string, unknown>>({
  * to avoid calling the Apps API on every setProfile request.
  * Cache key: account-workspace-appId. TTL: 5 minutes.
  */
-export const getCachedAppSettings = async (ctx: Context): Promise<Record<string, unknown>> => {
+export const getCachedAppSettings = async (
+  ctx: Context
+): Promise<Record<string, unknown>> => {
   const appId = process.env.VTEX_APP_ID ?? ''
-  const vtex = ctx.vtex
-  const account = vtex.account
-  const workspace = vtex.workspace
+  const { vtex } = ctx
+  const { account, workspace } = vtex
   const cacheKey = `${account}-${workspace}-${appId}`
 
   const cached = await settingsCache.getOrSet(cacheKey, () =>
@@ -26,5 +27,8 @@ export const getCachedAppSettings = async (ctx: Context): Promise<Record<string,
     }))
   )
 
-  return (cached != null && typeof cached === 'object' ? cached : {}) as Record<string, unknown>
+  return (cached != null && typeof cached === 'object' ? cached : {}) as Record<
+    string,
+    unknown
+  >
 }

--- a/node/utils/constants.ts
+++ b/node/utils/constants.ts
@@ -1,4 +1,31 @@
 export const CUSTOMER_SCHEMA_NAME = 'CL'
+
+// Entity + schema versions owned by vtex.b2b-organizations-graphql (node/mdSchema.ts).
+export const COST_CENTER_DATA_ENTITY = 'cost_centers'
+export const COST_CENTER_SCHEMA_VERSION = 'v0.0.8'
+export const COST_CENTER_FIELDS = [
+  'id',
+  'name',
+  'addresses',
+  'paymentTerms',
+  'organization',
+  'phoneNumber',
+  'businessDocument',
+  'stateRegistration',
+  'sellers',
+]
+export const ORGANIZATION_DATA_ENTITY = 'organizations'
+export const ORGANIZATION_SCHEMA_VERSION = 'v0.0.8'
+export const ORGANIZATION_FIELDS = [
+  'id',
+  'name',
+  'tradeName',
+  'status',
+  'priceTables',
+  'salesChannel',
+  'collections',
+  'sellers',
+]
 export const CUSTOMER_REQUIRED_FIELDS = [
   'email',
   'id',

--- a/node/utils/cookie.ts
+++ b/node/utils/cookie.ts
@@ -36,7 +36,7 @@ const checkoutCookieFormat = (orderFormId: string) =>
 const getOrderFormIdFromCookie = (cookies: Context['cookies']) => {
   const cookie = cookies.get(CHECKOUT_COOKIE)
 
-  return cookie && cookie.split('=')[1]
+  return cookie?.split('=')[1]
 }
 
 export {


### PR DESCRIPTION

### Changed

- `setProfile` no longer blocks the session response on cart/profile side effects (`clearCart`, `getB2BSettings`, `getMarketingTags`, `updateOrderFormShipping`, `updateOrderFormMarketingData`, `generateClUser`, `updateOrderFormProfile`). These only affect the cart/profile, not the session's own fields, so they now run in a detached chain after the response is sent — reducing `setProfile`'s response time and its exposure to `session-manager`'s 2s timeout on the transform call. Internal ordering (`clearCart` before the writes that follow it) is unchanged.
- `setProfile` reads cost centers from Master Data (`cost_centers`) via `masterDataExtended` instead of `b2b-organizations-graphql`. `getActiveUserByEmail` now searches `b2b_users` through the same client instead of paginating with the default Master Data client. Invalid-cost-center and inactive-organization fallbacks (`getOrganizationsByEmail` / `getOrganizationsPaginatedByEmail`) now search `b2b_users` and hydrate `cost_centers` / `organizations` the same way, instead of the GraphQL round-trip through `b2b-organizations-graphql`.
- `masterDataExtended` HTTP GETs (`getDocumentById`, `searchDocuments`) are cached in-process for 30 minutes, keyed per request URL so distinct documents/searches do not share a slot.

### Added

- New app setting `debug` (default `false`) to enable `setProfile` timing logs. When enabled, each `setProfile.timing` log includes `orderFormId` and the accumulated step timeline.