### PR TITLE
docs: auditorias de cobertura de logs do serviço

### DIFF
--- a/docs/log-coverage-audits/2026-08-21-log-coverage-audit-c3c6dbe.md
+++ b/docs/log-coverage-audits/2026-08-21-log-coverage-audit-c3c6dbe.md
@@ -1,0 +1,495 @@
+# Auditoria de cobertura de logs — `storefront-permissions`
+
+![escopo](https://img.shields.io/badge/escopo-node%2F-blue)
+![commit](https://img.shields.io/badge/commit-c3c6dbe-lightgrey)
+![score](https://img.shields.io/badge/cobertura-84%25-yellow)
+![missing](https://img.shields.io/badge/missing-11-critical)
+![insufficient](https://img.shields.io/badge/insufficient-6-orange)
+
+| | |
+|---|---|
+| **Data** | 2026-08-21 |
+| **Commit auditado** | `c3c6dbe` (branch `docs/log-coverage-audit`) |
+| **Escopo** | `node/**/*.ts` — 44 arquivos (exclui `*.d.ts` e `node/typings/`) |
+| **Unidade contada** | caminho de erro ou decisão que aborta/desvia a operação (bloco `catch`, `.catch()` que engole o erro, e branch de validação que interrompe um write) |
+| **Fora do denominador** | helpers puros sem efeito colateral, shims de rethrow (`statusToError`) e os caminhos latentes da seção [Latentes](#latentes-sem-call-site-atual) |
+
+> Auditoria independente. As duas auditorias anteriores foram registradas no commit `508bff6`
+> (2026-03-04); desde então `node/resolvers/Routes/index.ts` (+467 linhas) e
+> `node/resolvers/Queries/Users.ts` mudaram, então os números de linha antigos não valem mais aqui.
+
+---
+
+## Score
+
+**87 / 104 ≈ 84%**
+
+O denominador são os 104 caminhos de erro/decisão alcançáveis e com efeito colateral encontrados em
+`node/`. `covered` = existe log com contexto real (objeto de erro e/ou identificador) próximo ao
+caminho, em qualquer nível razoável.
+
+```mermaid
+pie showData
+    title Cobertura dos 104 caminhos julgados
+    "covered" : 87
+    "missing" : 11
+    "insufficient" : 6
+```
+
+### Cobertura por módulo
+
+| Módulo | Cobertura | | covered | missing | insufficient |
+|---|---:|---|---:|---:|---:|
+| `resolvers/Routes/` | 92% | `██████████████████░░` | 23 | 1 | 1 |
+| `directives/` | 88% | `█████████████████░░░` | 14 | 2 | 0 |
+| `resolvers/Queries/` | 87% | `█████████████████░░░` | 26 | 4 | 0 |
+| `resolvers/Mutations/` | 76% | `███████████████░░░░░` | 22 | 3 | 4 |
+| `metrics/` | 67% | `█████████████░░░░░░░` | 2 | 0 | 1 |
+| `clients/` | 0% | `░░░░░░░░░░░░░░░░░░░░` | 0 | 1 | 0 |
+
+O ponto fraco não é volume de log — o serviço loga bastante e com objeto de erro estruturado. O
+padrão que aparece nos achados é outro: **`.catch()` que converte falha de infraestrutura em valor de
+negócio** (`null`, `false`, `{}`, `[]`). Nesses pontos a falha não só passa sem log, ela passa
+disfarçada de resposta válida.
+
+---
+
+## Achados
+
+Ordenados por quanto a lacuna pode esconder uma falha real de produção.
+
+| # | Local | O que o caminho faz | Status | Por quê |
+|---|---|---|---|---|
+| 1 | `node/resolvers/Queries/Settings.ts:21` | lê `b2b_settings` do VBase antes de reescrevê-lo (`saveJSON` na linha 76) | `missing` | falha de leitura vira `{}`, o app conclui que não há settings, roda o re-sync de schema e **sobrescreve** `b2b_settings` com um objeto novo |
+| 2 | `node/resolvers/Mutations/Settings.ts:12` | lê `b2b_settings` antes de gravar `sessionWatcher` (`saveJSON` na linha 21) | `missing` | mesmo read-modify-write: falha de leitura descarta `adminSetup.schemaHash` e qualquer outra chave no save seguinte |
+| 3 | `node/resolvers/Mutations/Users.ts:135` | `getUser` — busca o usuário B2B no Masterdata | `missing` | `.catch(() => null)`; `null` é indistinguível de "usuário não existe". Consumido por `setProfile` (`Routes/index.ts:291`) e pelas mutations de vínculo (`:457`, `:510`, `:599`) |
+| 4 | `node/clients/checkout.ts:276` | `changeToAnonymousUser` — desvincula o carrinho do usuário anterior | `missing` | a condição está invertida: só re-lança quando **não** há `response` ou o código é 3xx, engolindo 4xx/5xx. Falha de desvínculo de carrinho passa em silêncio |
+| 5 | `node/directives/withUserPermissions.ts:24` | busca a sessão antes de resolver as permissões do usuário | `missing` | `.catch(() => null)` sem log e sem métrica; `sessionData` nulo segue para `checkUserPermission({ skipError: true })` |
+| 6 | `node/resolvers/Queries/Settings.ts:79` | `syncRoles` durante o bootstrap de settings | `missing` | `.catch(() => [])` faz `adminSetup.roles` virar `false` e ser persistido como se a sincronização tivesse rodado |
+| 7 | `node/resolvers/Mutations/Roles.ts:103` | `syncRoles` monta a lista de roles a persistir | `missing` | `if (currRole.name)` descarta em silêncio toda role cujo slug não está em `roleNames` do locale — role de permissão simplesmente não é criada |
+| 8 | `node/resolvers/Queries/Users.ts:789` | busca o perfil do usuário impersonado | `missing` | `.catch(() => null)` é traduzido para `{ error: 'User not found' }` na linha 792 — indisponibilidade do Profile System é reportada ao cliente como usuário inexistente |
+| 9 | `node/resolvers/Queries/Settings.ts:94` | lê `b2b_settings` em `getSessionWatcher` | `missing` | falha de leitura vira `{}` e o `?? true` da linha 99 devolve `sessionWatcher` ativo por padrão |
+| 10 | `node/resolvers/Routes/index.ts:103` | rota `appSettings` | `missing` | `getAppSettings` sem `try/catch` e sem log; a rota é pública e a falha sai sem contexto do app |
+| 11 | `node/directives/auditAccess.ts:17` | dispara a métrica de auditoria de acesso | `missing` | `this.sendAuthMetric(...)` é chamado sem `await` e sem `.catch()`; se os acessos a `request.headers` (`:29-40`) lançarem, a rejeição fica órfã e silenciosa |
+| 12 | `node/resolvers/Routes/index.ts:86` | `timedSetProfile` — instrumentação de falha de cada passo do `setProfile` | `insufficient` | loga em `logger.debug` (filtrado em produção) e **sem o objeto `error`**. É o único registro de *qual* passo falhou, e o `setProfile` não tem `try/catch` externo |
+| 13 | `node/resolvers/Mutations/Users.ts:149`<br>`node/resolvers/Mutations/Users.ts:177`<br>`node/resolvers/Mutations/Users.ts:222` | `updateUserFields`, `addSelectedPriceTableToB2bUser`, `createPermission` — writes no Masterdata | `insufficient` | mesmo padrão nos três: `if (error.response.status < 400)` trata erro como sucesso sem log, e o acesso direto a `.response` lança `TypeError` em erro de rede, mascarando o erro original |
+| 14 | `node/resolvers/Mutations/Users.ts:80` | `addUserToMasterdata` — recupera de `duplicated entry` buscando o documento existente | `insufficient` | colisão em criação de usuário é resolvida em silêncio; se a busca voltar vazia, `res[0].id` lança `TypeError` no lugar do erro real |
+| 15 | `node/utils/metrics/changeTeam.ts:54` | falha ao enviar a métrica de troca de organização | `insufficient` | usa `console.warn` em vez do `logger` estruturado e descarta o contexto que está à mão em `metricParams` (`userId`, `userEmail`, `orgId`, `costCenterId`) |
+
+---
+
+## Correções
+
+Snippets no estilo já usado no serviço: `logger.error({ error, message: '<escopo>.<causa>' })`.
+
+### 1 e 2 — read-modify-write de `b2b_settings`
+
+Os dois pontos leem, mutam e regravam a mesma chave do VBase. Falha de leitura precisa ser visível
+**e** não deve seguir para o `saveJSON`.
+
+`node/resolvers/Queries/Settings.ts:21` — `warn` + flag para não regravar:
+
+```ts
+let settingsReadFailed = false
+
+const settings = (await vbase.getJSON('b2b_settings', app).catch((error) => {
+  settingsReadFailed = true
+  logger.warn({
+    error,
+    message: 'getAppSettings.getSettingsError',
+    app,
+  })
+
+  return {}
+})) as { adminSetup: { schemaHash?: string | null; roles?: string[] | boolean | null } }
+```
+
+E na linha 76, não sobrescrever o que não foi lido:
+
+```ts
+if (settingsReadFailed) {
+  logger.warn({ message: 'getAppSettings.skipSaveAfterReadFailure', app })
+} else {
+  await vbase.saveJSON('b2b_settings', app, settings)
+}
+```
+
+`node/resolvers/Mutations/Settings.ts:12` — mesma leitura, e aqui o save é o objetivo da mutation,
+então o certo é abortar:
+
+```ts
+const settings: any = await vbase.getJSON('b2b_settings', app).catch((error) => {
+  logger.error({
+    error,
+    message: 'sessionWatcher.getSettingsError',
+    app,
+  })
+
+  throw error
+})
+```
+
+### 3 — `getUser` engolindo falha do Masterdata
+
+`node/resolvers/Mutations/Users.ts:103` não recebe `ctx`, só `masterdata`. Todos os quatro call sites
+têm `ctx`, então a correção é passar o `logger` adiante:
+
+```ts
+export const getUser = async ({
+  masterdata,
+  logger,
+  params: { email, id, userId },
+}: any) => {
+  const where = id || userId ? `id=${id || userId}` : `email=${email}`
+
+  return masterdata
+    .searchDocuments({ /* ...inalterado... */ })
+    .then((res: any) => (res.length > 0 ? res[0] : null))
+    .catch((error: any) => {
+      logger?.error({
+        error,
+        message: 'getUser.searchDocumentsError',
+        where,
+      })
+
+      return null
+    })
+}
+```
+
+Chamadas: `Routes/index.ts:291` e `Mutations/Users.ts:457`, `:510`, `:599` passam
+`logger: ctx.vtex.logger`.
+
+### 4 — `changeToAnonymousUser` com condição invertida
+
+`node/clients/checkout.ts:276`. A classe é um `JanusClient` e não tem `logger`; guarde `ctx.logger`
+no construtor (`IOContext` já o expõe) e corrija o predicado para engolir **apenas** o 3xx esperado:
+
+```ts
+// no construtor: this.logger = ctx.logger
+public changeToAnonymousUser = (orderFormId: string) => {
+  return this.get(this.routes.changeToAnonymousUser(orderFormId), {
+    metric: 'checkout-change-to-anonymous',
+  }).catch((err) => {
+    // Este endpoint responde com redirect, então 3xx é o caminho de sucesso.
+    if (/^3..$/.test(String((err as AxiosError).response?.status ?? ''))) {
+      return
+    }
+
+    this.logger.error({
+      error: err,
+      message: 'checkout.changeToAnonymousUserError',
+      orderFormId,
+    })
+
+    throw err
+  })
+}
+```
+
+### 5 — sessão nula no directive de permissões
+
+`node/directives/withUserPermissions.ts:24`:
+
+```ts
+context.vtex.sessionData = await session
+  .getSession(context.vtex.sessionToken as string, ['*'])
+  .then((currentSession: any) => currentSession.sessionData)
+  .catch((error: any) => {
+    context.vtex.logger.warn({
+      error,
+      message: 'withUserPermissions.getSessionError',
+      operation: field.astNode?.name?.value ?? context.request.url,
+    })
+
+    return null
+  })
+```
+
+### 6 — `syncRoles` no bootstrap de settings
+
+`node/resolvers/Queries/Settings.ts:79`:
+
+```ts
+const roles: any = await syncRoles(ctx).catch((error) => {
+  logger.error({
+    error,
+    message: 'getAppSettings.syncRolesError',
+  })
+
+  return []
+})
+```
+
+### 7 — role descartada em silêncio
+
+`node/resolvers/Mutations/Roles.ts:103`:
+
+```ts
+if (currRole.name) {
+  newRoles.push(currRole)
+} else if (roleIndex === -1) {
+  ctx.vtex.logger.warn({
+    message: 'syncRoles.roleNameNotFound',
+    slug,
+    locale: ctx.vtex.tenant?.locale,
+  })
+}
+```
+
+### 8 — perfil do usuário impersonado
+
+`node/resolvers/Queries/Users.ts:789`:
+
+```ts
+const userData: any = await profileSystem
+  .getProfileInfo(profile.id.value)
+  .catch((error: any) => {
+    logger.error({
+      error,
+      message: 'checkImpersonation.getProfileInfoError',
+      profileId: profile.id.value,
+    })
+
+    return null
+  })
+```
+
+### 9 — `getSessionWatcher`
+
+`node/resolvers/Queries/Settings.ts:94`:
+
+```ts
+const settings: any = await vbase.getJSON('b2b_settings', app).catch((error) => {
+  logger.warn({
+    error,
+    message: 'getSessionWatcher.getSettingsError',
+    app,
+  })
+
+  return {}
+})
+```
+
+Vale notar que o `try/catch` da linha 98 envolve só o `settings?.sessionWatcher?.active ?? true` —
+uma leitura de propriedade opcional que praticamente não lança. O `catch` da linha 100 está no lugar
+errado; a falha real está na linha 94.
+
+### 10 — rota `appSettings`
+
+`node/resolvers/Routes/index.ts:103`:
+
+```ts
+appSettings: async (ctx: Context) => {
+  const appId = process.env.VTEX_APP_ID ? process.env.VTEX_APP_ID : ''
+
+  try {
+    const { disableSellersNameFacets, disablePrivateSellersFacets } =
+      await ctx.clients.apps.getAppSettings(appId)
+
+    return { disableSellersNameFacets, disablePrivateSellersFacets }
+  } catch (error) {
+    ctx.vtex.logger.error({
+      error,
+      message: 'appSettings.getAppSettingsError',
+      appId,
+    })
+
+    throw error
+  }
+},
+```
+
+### 11 — métrica de auditoria órfã
+
+`node/directives/auditAccess.ts:17`:
+
+```ts
+this.sendAuthMetric(field, context).catch((error) => {
+  context.vtex.logger.warn({
+    error,
+    message: 'auditAccess.sendAuthMetricError',
+    operation: field.astNode?.name?.value,
+  })
+})
+```
+
+### 12 — instrumentação do `setProfile` cega em produção
+
+`node/resolvers/Routes/index.ts:86`. O `catch` já tem o `error` em mãos; hoje ele não vai para o log
+e o nível `debug` não é indexado em produção. Como o `setProfile` não tem `try/catch` externo, este é
+o único ponto que sabe **qual** passo quebrou:
+
+```ts
+} catch (error) {
+  const now = Date.now()
+  const stepTiming: SetProfileStepTiming = {
+    step,
+    durationMs: now - start,
+    failed: true,
+    totalMs: now - timing.t0,
+  }
+
+  steps.push(stepTiming)
+
+  logger.error({
+    error,
+    message: 'setProfile.stepFailed',
+    step,
+    durationMs: stepTiming.durationMs,
+    totalMs: stepTiming.totalMs,
+    steps: [...steps],
+  })
+  throw error
+}
+```
+
+O `logger.debug` do caminho de sucesso (`:39` e `:66`) pode ficar como está — ali `debug` é a escolha
+certa para timing de alto volume.
+
+### 13 e 14 — writes no Masterdata que tratam erro como sucesso
+
+Padrão repetido em `node/resolvers/Mutations/Users.ts:149`, `:177` e `:222`. Vale extrair um helper
+único em vez de corrigir os três no lugar:
+
+```ts
+const resolveWriteConflict = (
+  { error, id, operation, logger }: any
+) => {
+  const status = error?.response?.status
+
+  if (status && status < 400) {
+    logger.warn({
+      error,
+      message: `${operation}.nonErrorStatus`,
+      id,
+      status,
+    })
+
+    return { DocumentId: id }
+  }
+
+  logger.error({ error, message: `${operation}.writeError`, id, status })
+
+  throw error
+}
+```
+
+Ler `error?.response?.status` com optional chaining também remove o `TypeError` que hoje mascara
+erros de rede. Em `:80` (`addUserToMasterdata`), o mesmo cuidado no branch de `duplicated entry`:
+
+```ts
+.catch((error: any) => {
+  if (error.response?.data?.Message === 'duplicated entry') {
+    logger.warn({ error, message: 'addUserToMasterdata.duplicatedEntry', email })
+
+    return masterdata
+      .searchDocuments({ /* ...inalterado... */ })
+      .then((res: [{ id: string }]) => {
+        if (!res?.length) {
+          logger.error({
+            message: 'addUserToMasterdata.duplicatedEntryNotFound',
+            email,
+          })
+          throw error
+        }
+
+        return { DocumentId: res[0].id }
+      })
+  }
+
+  throw error
+})
+```
+
+### 15 — `console.warn` na métrica de troca de organização
+
+`node/utils/metrics/changeTeam.ts:54`. `console.*` não entra no índice de logs da VTEX IO da mesma
+forma que `ctx.vtex.logger`, e o contexto está todo em `metricParams`:
+
+```ts
+export const sendChangeTeamMetric = async (
+  metricParams: ChangeTeamParams,
+  logger?: Context['vtex']['logger']
+) => {
+  try {
+    const metric = buildMetric(metricParams)
+
+    await sendMetric(metric)
+  } catch (error) {
+    logger?.warn({
+      error,
+      message: 'sendChangeTeamMetric.sendMetricError',
+      userId: metricParams.userId,
+      orgId: metricParams.orgId,
+      costCenterId: metricParams.costCenterId,
+    })
+  }
+}
+```
+
+O call site em `node/resolvers/Mutations/Users.ts:696` passa `ctx.vtex.logger`.
+
+---
+
+## Latentes (sem call site atual)
+
+`node/utils/LicenseManager.ts` não tem **nenhuma** chamada de log e concentra seis `.catch()` que
+devolvem `null` / `false` / `{}` sem registrar nada: `:29` (`getUserIdByEmail`), `:50` e `:58`
+(`saveUser`), `:74` (`deleteUser`), `:119` e `:137` (`hasBuyerOrganizationViewRole` /
+`hasBuyerOrganizationEditRole`).
+
+Os dois últimos são os mais desconfortáveis conceitualmente — uma verificação de permissão que
+devolve `false` tanto para "não tem a role" quanto para "o License Manager está fora". **Nenhum dos
+seis tem call site no repositório hoje**, então ficam fora do denominador: são risco latente, não
+ponto cego em produção. Se algum voltar a ser usado, precisa de log antes.
+
+Os dois métodos do arquivo que estão de fato no caminho de autenticação — `getUserAdminPermissions`
+(`:81`) e `checkUserSpecificRole` (`:89`) — não engolem erro: propagam para `directives/helper.ts`,
+que loga nos `catch` das linhas 70, 157 e 210. Esses contam como `covered`.
+
+---
+
+## Padrão transversal: `throw new Error(error)`
+
+Seis sites re-lançam o erro assim: `Queries/Users.ts:128`, `:844`, `:914`, `:969`,
+`Queries/Settings.ts:72` e `Queries/Roles.ts:59`.
+
+`new Error(error)` serializa o objeto para string — o erro que chega ao chamador vira
+`Error: [object Object]`, sem `response`, sem status e sem a stack original. Nos cinco primeiros já
+existe um `logger.error` local antes do `throw`, então **não conta como achado** e não muda o score.
+Ainda vale trocar por `throw error` (ou `new Error(message, { cause: error })`), porque hoje qualquer
+log a montante desses pontos é inútil. `Queries/Roles.ts:59` é o único sem log local, coberto apenas
+pelos chamadores (`:77` e `:110`).
+
+---
+
+## Verificado e considerado adequado
+
+Registrado para que decisões deliberadas não sejam reabertas na próxima auditoria.
+
+- **`node/directives/withSession.ts:26`** — `.catch(() => null)` sem log é **intencional**. O
+  comentário das linhas 28-31 explica a troca de log por métrica (`SessionMetric`) justamente por
+  volume alto de logs nesse caminho. Continua adequado.
+- **`node/resolvers/Routes/index.ts:890`** — `Promise.all(promises)` sem `await` e sem `.catch()` é
+  intencional ("avoid session timeout"). Cada promise da lista já tem `.catch()` com `logger.error`
+  antes de entrar em `timedSetProfile`, então nenhuma rejeição fica órfã.
+- **`node/directives/helper.ts`** — as quatro funções de validação de token logam negação de acesso
+  com contexto (`:42`, `:72`, `:129`, `:159`, `:212`). É o módulo mais bem coberto do serviço.
+- **`node/resolvers/Routes/index.ts`** — os doze `catch` do `setProfile` (`:317`, `:343`, `:378`,
+  `:433`, `:457`, `:497`, `:706`, `:741`, `:777`, `:805`, `:827`, `:879`) têm `logger.error`/`warn`
+  adjacente com objeto de erro. O único problema do arquivo é o `timedSetProfile` (achado 12).
+- **`node/resolvers/Queries/Roles.ts:43`** — o branch de 404 cai para o Masterdata; é o caminho
+  normal de bootstrap quando o VBase ainda não tem `b2b_roles`, não um erro.
+- **`node/services/appSettingsCache.ts`** — sem log e sem `catch` de propósito: a falha de
+  `getAppSettings` propaga para quem chama, e os chamadores logam (`Queries/Users.ts:701`).
+- **`node/clients/metrics.ts:15`** — `axios.post` sem tratamento; os três chamadores envolvem em
+  `try/catch` (`metrics/auth.ts:43`, `metrics/session.ts:38`, `utils/metrics/changeTeam.ts:53`).
+- **Shims `statusToError`** (`clients/checkout.ts`, `utils/LicenseManager.ts:142-156`) — convertem e
+  propagam o erro, não engolem. Fora do denominador.
+
+## Observação fora de escopo
+
+`node/resolvers/Routes/index.ts:900` loga `JSON.stringify(body)` e `JSON.stringify(response)`
+completos em `logger.info` a cada `setProfile`. Não é lacuna de cobertura, mas o payload carrega
+e-mail, endereço e dados de perfil — vale revisar volume e PII junto com o time.

--- a/docs/log-coverage-audits/2026-08-21-log-coverage-audit-review.md
+++ b/docs/log-coverage-audits/2026-08-21-log-coverage-audit-review.md
@@ -1,0 +1,333 @@
+# Auditoria de cobertura de logs (revisão independente) — 2026-08-21
+
+| | |
+|---|---|
+| **Escopo** | `node/` (todo o serviço) |
+| **Branch** | `B2BTEAM-3227` |
+| **Commit** | `508bff6` |
+| **Score** | **86/112 ≈ 77%** (excluindo código morto: 86/105 ≈ 82%) |
+
+Segunda auditoria sobre o **mesmo commit** da
+[auditoria anterior](./2026-08-21-log-coverage-audit.md), feita de forma independente para servir de
+contraprova. O denominador conta **locais distintos que precisam de log** — tanto os que já têm
+(86) quanto os que faltam ou estão insuficientes (26). Caminhos triviais e sem efeito colateral
+(getters, formatadores, early returns do fluxo normal, arquivos de tipo) ficam fora.
+
+O score não é comparável ao 89% da auditoria anterior: aquela contou 95 caminhos com granularidade
+diferente. As duas conclusões qualitativas coincidem em 8 dos 10 achados originais; as diferenças
+estão registradas abaixo.
+
+## Resumo
+
+Confirmo o diagnóstico geral: o serviço é bem instrumentado. A camada de autenticação
+(`directives/helper.ts` + os quatro directives de acesso) loga **todo** caminho de negação com
+`logger.warn` e contexto rico de métricas, e praticamente todo resolver de mutation loga com
+objeto `error` mais um identificador.
+
+Mas encontrei um caminho de falha silenciosa **mais grave que qualquer um dos dez achados
+anteriores**, e ele estava fora daquela lista: `setProfile` não tem tratamento de erro no nível
+superior, e seis chamadas a clientes externos dentro dele não têm `.catch()` nenhum.
+
+## Achados
+
+| Local | O que o caminho faz | Status | Por quê |
+|---|---|---|---|
+| `node/resolvers/Routes/index.ts:282-296`, `:21` e `node/services/appSettingsCache.ts:22` | `setProfile` — busca organização, cost center, sales channels, marketing tags, B2B settings e app settings | **missing** | `setProfile` não tem `try/catch` externo e 6 dessas chamadas não têm `.catch()`. Uma indisponibilidade do `b2b-organizations-graphql` derruba **todo** `setProfile` sem uma linha de log do serviço |
+| `node/resolvers/Mutations/Users.ts:135` (+ callers `:460`, `:513`, `:602`) | `getUser` — busca usuário no MasterData | missing | `.catch(() => null)` engole a falha; os 3 callers lançam `'User not found'` fora do `try`, sem log |
+| `node/resolvers/Queries/Users.ts:607` | Resolve permissões quando o `roleId` do usuário não existe mais | missing | Com `skipError: true` retorna permissões vazias sem log — usuário perde acesso silenciosamente |
+| `node/resolvers/Queries/Users.ts:752` | `checkImpersonation` — busca perfil | missing | `.catch(() => null)` vira `{ error: 'User not found' }`, indistinguível de indisponibilidade do Profile System |
+| `node/resolvers/Mutations/Users.ts:605` e `node/resolvers/Queries/Settings.ts:76` | Escritas: `updateUserFields` e `vbase.saveJSON` | **missing** | Duas operações de escrita fora de qualquer `try/catch`; a falha vira 500 sem log local |
+| `node/directives/withUserPermissions.ts:24` | Carrega sessão antes de resolver permissões | missing | `.catch(() => null)` sem log nem métrica (o irmão `withSession.ts` emite `SessionMetric` nesse mesmo ponto) |
+| `node/resolvers/Queries/Settings.ts:79` | `syncRoles` no setup do app | missing | `.catch(() => [])` faz a UI reportar "roles não configuradas" sem explicar o motivo |
+| `node/resolvers/Queries/Users.ts:246-250` | `checkCustomerSchema` — query exposta no schema | **missing** | `getLatestSchema` sem `catch` e o branch `'Schema not found'` retorna erro ao cliente sem logar |
+| `node/resolvers/Queries/Roles.ts:59` | `searchRoles` relança erro não-404 | insufficient | `throw new Error(error)` estringa o objeto; o `logger.error` do caller em `:77` grava `[object Object]` |
+| `node/utils/metrics/changeTeam.ts:54` | Envio de métrica de troca de time | insufficient | Usa `console.warn`, que não entra no índice estruturado; o equivalente `metrics/session.ts:39` usa `logger.error` |
+| `node/resolvers/Queries/Settings.ts:21`, `:94` e `node/resolvers/Mutations/Settings.ts:12` | Leitura de settings no VBase | insufficient | `.catch(() => ({}))` trata 404 de primeira execução e indisponibilidade do VBase da mesma forma |
+| `node/utils/LicenseManager.ts:29,50,58,74,119,137` | Cliente do License Manager | missing | Arquivo sem nenhum log; 6 catches retornam `null` / `false` / `{}` em silêncio |
+| `node/clients/checkout.ts:276` | `changeToAnonymousUser` | missing | Engole todo erro não-3xx sem log |
+
+Os dois últimos continuam sendo **código morto**. Confirmei por busca: `getUserIdByEmail`,
+`saveUser`, `deleteUser`, `hasBuyerOrganizationViewRole` e `hasBuyerOrganizationEditRole` não têm
+chamador, e `changeToAnonymousUser` também não. Só `getUserAdminPermissions` e
+`checkUserSpecificRole` são usados (de `helper.ts:52,58,139,145`), e ambos propagam via
+`statusToError` até o `catch` logado de `helper.ts:70`.
+
+## Nota sobre o `master`
+
+O commit auditado (`508bff6`) está **35 commits atrás do `origin/master`** no momento da abertura
+deste PR, e o `master` reescreveu `Routes/index.ts` (+467 linhas alteradas) e `Queries/Users.ts`.
+Os números de linha acima valem para `508bff6`. Reconferi o achado principal contra o `master`:
+
+- `setProfile` agora envolve cada chamada em `timedSetProfile` (`Routes/index.ts:49`), que tem
+  `try/catch` por passo. **O achado continua aberto, mas com outra forma**: o `catch` (`:75`) loga
+  em `logger.debug` com `failed: true` e **sem o objeto `error`**, e depois relança. Ou seja, a
+  falha vira um evento de timing em nível `debug` — normalmente filtrado em produção — em vez de um
+  `logger.error` com o erro. O passo que falhou passou a ser identificável, o erro em si não.
+- `setProfile` continua **sem `try/catch` no nível superior**.
+- `Routes.appSettings` (`master:103`) e `services/appSettingsCache.ts:22` continuam sem guarda.
+
+A correção sugerida no item 1 deve ser adaptada: em vez de embrulhar as promessas do `Promise.all`,
+o mais direto é fazer o `catch` do `timedSetProfile` logar `logger.error({ error, message:
+'setProfile.stepFailed', step })` antes do `throw`, e adicionar o `try/catch` externo.
+
+## Divergências da auditoria anterior
+
+Três correções, todas verificadas no código:
+
+1. **`Queries/Users.ts:592` não é um achado.** A auditoria anterior apontou `:592` e `:607` juntos
+   como o achado mais grave. Mas `getUserByEmail` (`:195`) retorna sempre `[user]` — um array de um
+   elemento — então `!userData.length` nunca é verdadeiro e o branch de `:592` é inalcançável. Mais
+   importante: quando o usuário não existe, `getActiveUserByEmail:168` **já emite**
+   `logger.warn({ email, message: 'getActiveUserByEmail-userNotFound' })`. Esse caminho está coberto.
+   O que sobra de real é só `:607` — usuário existe mas o `roleId` aponta para uma role que não
+   existe mais.
+
+2. **`Queries/Users.ts:750` é `:752`.** O `.catch(() => null)` está em `:752`; `:750` é o início
+   da expressão.
+
+3. **Quatro achados novos**, nenhum na lista anterior: as chamadas sem guarda em `setProfile`
+   (incluindo `services/appSettingsCache.ts`, arquivo que não aparece na auditoria anterior nem
+   como achado nem como verificado), as duas escritas fora de `try/catch`, e `checkCustomerSchema`.
+
+## Verificado e considerado adequado
+
+- **`node/directives/helper.ts`** — os 3 catches (`:70`, `:157`, `:210`) logam `warn` + `err`, e os
+  branches de token de outra conta (`:42`, `:129`) logam com `account` e `user`.
+- **Os quatro directives de acesso** (`checkAdminAccess`, `checkUserAccess`,
+  `validateAdminUserAccess`, `validateStoreUserAccess`) — todo caminho de negação loga `warn` com o
+  conjunto completo de `metricFields`. Cobertura exemplar.
+- **`node/directives/withSession.ts:26`** — o `.catch(() => null)` é deliberado e documentado no
+  próprio código: trocado por `SessionMetric` por volume de log.
+- **`node/resolvers/Mutations/Users.ts:80,149,177,222`** — tratam um caso conhecido (status < 400) e
+  dão `throw error`, caindo nos callers que logam.
+- **`node/resolvers/Routes/utils/index.ts`** — `generateClUser` e `getUserOrganizationsData` logam
+  em cada ponto de falha, com `email` e `page` como contexto.
+- **`node/resolvers/Routes/index.ts` (`checkPermissions` e o resto de `setProfile`)** — 14 caminhos
+  de falha, todos logados com contexto suficiente.
+- **`node/metrics/session.ts` e `node/metrics/auth.ts`** — falha de envio de métrica é logada.
+- **`node/resolvers/Queries/Roles.ts:43`** — o branch 404 é a primeira execução (VBase vazio) e cai
+  no fallback do MasterData; logar ali seria ruído.
+- **`node/resolvers/Routes/index.ts:249`** — o early return para usuário sem `orgId` é o caminho
+  normal de todo shopper B2C.
+
+## Correções sugeridas
+
+### 1. `Routes/index.ts` — `setProfile` sem tratamento de erro no topo
+
+Achado mais grave. Hoje, um timeout de 5s no `b2b-organizations-graphql` faz `setProfile` responder
+500 sem que o serviço registre nada — e `setProfile` roda em toda sessão de shopper B2B.
+
+Duas correções complementares. Primeiro, guardar cada promessa do `Promise.all` para que a falha
+seja atribuível ao cliente certo:
+
+```typescript
+    const settle = <T>(promise: Promise<T>, message: string) =>
+      promise.catch((error) => {
+        logger.error({ error, message, orgId: user.orgId, costId: user.costId })
+
+        return null
+      })
+
+    const [
+      organizationResponse,
+      costCenterResponse,
+      salesChannels,
+      marketingTagsResponse,
+      b2bSettingsResponse,
+      appSettings,
+    ] = await Promise.all([
+      getOrganization(user.orgId),
+      settle(organizations.getCostCenterById(user.costId), 'setProfile.getCostCenterByIdError'),
+      settle(salesChannelClient.getSalesChannel(), 'setProfile.getSalesChannelError'),
+      settle(organizations.getMarketingTags(user.costId), 'setProfile.getMarketingTagsError'),
+      settle(organizations.getB2BSettings(), 'setProfile.getB2BSettingsError'),
+      settle(getCachedAppSettings(ctx), 'setProfile.getAppSettingsError'),
+    ])
+```
+
+Isso exige checar `null` nos consumidores — hoje `:329` já quebra com `organization.status` quando
+`getOrganization` cai no `.catch` e retorna `undefined`, então esse endurecimento é necessário de
+qualquer forma.
+
+Segundo, um `try/catch` externo em `setProfile` como rede de segurança, para que nenhuma exceção
+inesperada saia sem log:
+
+```typescript
+  setProfile: async (ctx: Context) => {
+    const {
+      vtex: { logger },
+    } = ctx
+
+    try {
+      // corpo atual
+    } catch (error) {
+      logger.error({ error, message: 'setProfile.unhandledError' })
+      throw error
+    }
+  },
+```
+
+O mesmo vale para `Routes.appSettings` (`:21`), chamado em `:426` sem guarda.
+
+### 2. `Mutations/Users.ts:135` — `getUser` engole falha do MasterData
+
+A função não recebe `ctx`, então o `logger` precisa entrar como parâmetro:
+
+```typescript
+export const getUser = async ({
+  masterdata,
+  logger,
+  params: { email, id, userId },
+}: any) => {
+  // ...
+    .catch((error: any) => {
+      logger?.error({
+        error,
+        message: 'getUser.searchDocumentsError',
+        id: id ?? userId,
+        email,
+      })
+
+      return null
+    })
+}
+```
+
+Nos três call sites (`addOrganizationToUser:457`, `addCostCenterToUser:510`,
+`setActiveUserByOrganization:599`), passar `logger` e logar antes do
+`throw new Error('User not found')` — hoje esse throw sai sem registro algum.
+
+### 3. `Queries/Users.ts:607` — role órfã derruba permissões em silêncio
+
+```typescript
+  if (!userRole) {
+    logger.warn({
+      email,
+      message: 'getRoleAndPermissionsByEmail-roleNotFound-degraded',
+      roleId: userData[0].roleId,
+    })
+
+    return defaultResponse
+  }
+```
+
+Vale notar que `getRole` (`Queries/Roles.ts:63`) retorna `{ status: 'error', message }` em caso de
+falha — um objeto **truthy**. Ou seja, o `!userRole` acima não pega o caso de erro; ele cai adiante
+com `features` `undefined` e devolve permissões vazias. A falha em si já é logada em `Roles.ts:77`,
+mas o ideal é `getRole` devolver `null` no catch para que os dois casos convirjam neste branch.
+
+### 4. `Queries/Users.ts:752` — impersonation
+
+```typescript
+    const userData: any = await profileSystem
+      .getProfileInfo(profile.id.value)
+      .catch((error: any) => {
+        logger.error({
+          error,
+          message: 'checkImpersonation.getProfileInfoError',
+          profileId: profile.id.value,
+        })
+
+        return null
+      })
+```
+
+### 5. `Mutations/Users.ts:605` e `Queries/Settings.ts:76` — escritas sem guarda
+
+Mover `updateUserFields` para dentro do `try` que já existe logo abaixo (`:613`) resolve o primeiro
+caso. Para o `vbase.saveJSON` de `getAppSettings`, um `.catch` que loga e segue evita que o setup do
+app falhe inteiro por causa da persistência do hash de schema.
+
+### 6. `directives/withUserPermissions.ts:24`
+
+Replicar o que `withSession.ts` já faz: destruturar `logger` de `context.clients` e emitir
+`SessionMetric` após o `.catch(() => null)`, para que os dois directives tenham a mesma visibilidade
+sobre sessão ausente.
+
+### 7. `Queries/Settings.ts:79`
+
+```typescript
+  const roles: any = await syncRoles(ctx).catch((error) => {
+    logger.error({
+      error,
+      message: 'getAppSettings.syncRolesError',
+    })
+
+    return []
+  })
+```
+
+### 8. `Queries/Users.ts:246` — `checkCustomerSchema`
+
+Query exposta que hoje responde `{ status: 'error' }` sem log:
+
+```typescript
+  const latestSchema = await schema
+    .getLatestSchema(CUSTOMER_SCHEMA_NAME)
+    .catch((error: any) => {
+      logger.error({
+        error,
+        message: 'checkCustomerSchema.getLatestSchemaError',
+        schemaName: CUSTOMER_SCHEMA_NAME,
+      })
+
+      return null
+    })
+
+  if (!latestSchema) {
+    logger.warn({
+      message: 'checkCustomerSchema-schemaNotFound',
+      schemaName: CUSTOMER_SCHEMA_NAME,
+    })
+
+    return { status: 'error', message: 'Schema not found' }
+  }
+```
+
+### 9. `Queries/Roles.ts:59`
+
+Trocar `throw new Error(error)` por `throw error` preserva stack e response, e faz o `logger.error`
+de `getRole` gravar o erro real. O mesmo padrão aparece em `Users.ts:127,807,877,932` e
+`Settings.ts:72`, mas nesses casos o log já aconteceu antes do rethrow, então só o de `Roles.ts`
+degrada o registro.
+
+### 10. `utils/metrics/changeTeam.ts:54`
+
+Alinhar com `metrics/session.ts`, recebendo o logger:
+
+```typescript
+export const sendChangeTeamMetric = async (
+  logger: Logger,
+  metricParams: ChangeTeamParams
+) => {
+  try {
+    await sendMetric(buildMetric(metricParams))
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'Unable to send change team metric',
+    })
+  }
+}
+```
+
+O call site em `Mutations/Users.ts:696` passa a ser `sendChangeTeamMetric(logger, metricParams)`.
+
+### 11, 12 e 13
+
+Baixa prioridade. O item 11 (leituras de settings no VBase) tem impacto pequeno; os itens 12
+(`LicenseManager`) e 13 (`changeToAnonymousUser`) são código sem chamador — vale revisitar se e
+quando esses métodos voltarem a ser usados.
+
+## Metodologia
+
+Pré-scan por regex (`entry points`, `catch`, chamadas de log e nível detectado) sobre os 45 arquivos
+`.ts` de `node/` que não são só de tipo, seguido de leitura do contexto em torno de cada ponto
+sinalizado. Grep de call sites para separar código vivo de código morto. Cada local foi julgado em
+uma de três categorias:
+
+- **missing** — nenhuma chamada de log no caminho de falha.
+- **insufficient** — existe log, mas sem objeto de erro, sem identificador, ou em um canal que não
+  chega ao índice estruturado.
+- **covered** — log com contexto real em qualquer nível razoável. `warn` em falha esperada e tratada
+  conta como coberto tanto quanto `error`.

--- a/docs/log-coverage-audits/2026-08-21-log-coverage-audit-review.md
+++ b/docs/log-coverage-audits/2026-08-21-log-coverage-audit-review.md
@@ -13,9 +13,10 @@ contraprova. O denominador conta **locais distintos que precisam de log** — ta
 (86) quanto os que faltam ou estão insuficientes (26). Caminhos triviais e sem efeito colateral
 (getters, formatadores, early returns do fluxo normal, arquivos de tipo) ficam fora.
 
-O score não é comparável ao 89% da auditoria anterior: aquela contou 95 caminhos com granularidade
-diferente. As duas conclusões qualitativas coincidem em 8 dos 10 achados originais; as diferenças
-estão registradas abaixo.
+O score não é comparável ao 89% da auditoria anterior, que mistura duas unidades de contagem no
+denominador — a reconciliação completa está em
+[Reconciliação dos scores](#reconciliação-dos-scores-89-vs-77). As duas conclusões qualitativas
+coincidem em 8 dos 10 achados originais; as diferenças estão registradas abaixo.
 
 ## Resumo
 
@@ -88,6 +89,42 @@ Três correções, todas verificadas no código:
 3. **Quatro achados novos**, nenhum na lista anterior: as chamadas sem guarda em `setProfile`
    (incluindo `services/appSettingsCache.ts`, arquivo que não aparece na auditoria anterior nem
    como achado nem como verificado), as duas escritas fora de `try/catch`, e `checkCustomerSchema`.
+
+### Reconciliação dos scores (89% vs. 77%)
+
+Os dois scores não medem a mesma coisa, e a diferença não é só de granularidade — há uma
+inconsistência de unidade na primeira auditoria.
+
+O lado **coberto** das duas praticamente coincide: 85 contra 86. As duas encontraram
+essencialmente o mesmo conjunto de caminhos já instrumentados. Toda a diferença está no
+denominador.
+
+A primeira fechou `85 + 10 = 95`: contou os caminhos cobertos **um por um**, mas os achados como
+**linhas de tabela agrupadas**. Só que várias daquelas linhas agrupam vários locais distintos —
+`LicenseManager` é uma linha com 6 catches, `getUser` é uma linha com o `.catch` mais 3 callers, as
+leituras do VBase são uma linha com 3 locais. Expandidas para locais, as 10 linhas dela somam **21**,
+não 10. O denominador mistura 85 unidades de um tipo com 10 de outro, o que subestima o lado dos
+achados e infla o score.
+
+Esta auditoria usa uma unidade só: local que precisa de uma linha de log. Daí `86 + 26 = 112`.
+
+Os números reconciliam exatamente:
+
+```
+21  locais dos 10 achados da auditoria anterior
+-1  Queries/Users.ts:592 (inalcançável, e já logado a montante)
++3  setProfile sem guarda (Promise.all, Routes.appSettings, appSettingsCache)
++2  escritas fora de try/catch (Mutations/Users.ts:605, Queries/Settings.ts:76)
++1  checkCustomerSchema
+=26 locais de achado desta auditoria
+```
+
+Normalizada para a mesma unidade, a auditoria anterior daria **85/106 ≈ 80%**, não 89%. A diferença
+restante até os 77% daqui são justamente os 6 locais dos achados novos — comportamento esperado:
+mesma base de código, mais achados, score um pouco menor.
+
+Conclusão prática: o serviço nunca esteve em 89%. Estava em ~80% pela contagem anterior e está em
+77% por esta, que é a mais defensável por não misturar unidades.
 
 ## Verificado e considerado adequado
 

--- a/docs/log-coverage-audits/2026-08-21-log-coverage-audit.md
+++ b/docs/log-coverage-audits/2026-08-21-log-coverage-audit.md
@@ -1,0 +1,198 @@
+# Auditoria de cobertura de logs — 2026-08-21
+
+| | |
+|---|---|
+| **Escopo** | `node/` (todo o serviço) |
+| **Branch** | `B2BTEAM-3227` |
+| **Commit** | `508bff6` |
+| **Score** | **85/95 ≈ 89%** |
+
+O denominador são 95 caminhos de erro/decisão julgados: blocos `catch`, `.catch()` e branches de
+validação que abortam ou degradam a operação. Caminhos triviais e sem efeito colateral (getters,
+formatadores, arquivos de tipo) foram ignorados.
+
+## Resumo
+
+O repositório é, no geral, bem instrumentado. Toda a camada de autenticação (`directives/helper.ts`
+e os quatro directives de acesso) e praticamente todos os resolvers de mutation logam com
+`logger.error` / `logger.warn` incluindo o objeto `error` e algum identificador que permite achar o
+registro afetado.
+
+Os 10 achados abaixo são caminhos onde uma falha real de produção não deixa rastro nenhum — ou deixa
+um rastro inútil para debug.
+
+## Achados
+
+| Local | O que o caminho faz | Status | Por quê |
+|---|---|---|---|
+| `node/resolvers/Queries/Users.ts:592` e `:607` | Resolve role e permissões por e-mail | missing | Com `skipError: true` retorna permissões vazias sem logar; os `logger.warn` existentes só disparam no branch `!skipError` |
+| `node/resolvers/Mutations/Users.ts:135` | `getUser` — busca usuário no MasterData | missing | `.catch(() => null)` engole qualquer falha; 3 callers (`:459`, `:512`, `:601`) lançam `'User not found'` fora do `try`, sem log |
+| `node/resolvers/Queries/Users.ts:750` | `checkImpersonation` — busca perfil | missing | `.catch(() => null)` vira `{ error: 'User not found' }`, indistinguível de indisponibilidade do Profile System |
+| `node/directives/withUserPermissions.ts:24` | Carrega sessão antes de resolver permissões | missing | `.catch(() => null)` sem log nem métrica (o irmão `withSession.ts` emite `SessionMetric` nesse mesmo ponto) |
+| `node/resolvers/Queries/Settings.ts:79` | `syncRoles` no setup do app | missing | `.catch(() => [])` faz a UI reportar "roles não configuradas" sem explicar o motivo |
+| `node/resolvers/Queries/Roles.ts:59` | `searchRoles` relança erro não-404 | insufficient | `throw new Error(error)` estringa o objeto; o `logger.error` do caller em `:77` grava `[object Object]` |
+| `node/utils/metrics/changeTeam.ts:54` | Envio de métrica de troca de time | insufficient | Usa `console.warn`, que não entra no índice estruturado; o equivalente `metrics/session.ts:39` usa `logger.error` |
+| `node/resolvers/Queries/Settings.ts:21`, `:94` e `node/resolvers/Mutations/Settings.ts:12` | Leitura de settings no VBase | insufficient | `.catch(() => ({}))` trata 404 de primeira execução e indisponibilidade do VBase da mesma forma |
+| `node/utils/LicenseManager.ts:29,50,58,74,119,137` | Cliente do License Manager | missing | Arquivo sem nenhum log; 6 catches retornam `null` / `false` / `{}` em silêncio |
+| `node/clients/checkout.ts:276` | `changeToAnonymousUser` | missing | Engole todo erro não-3xx sem log |
+
+Os dois últimos são **código morto no momento desta auditoria**: só `getUserAdminPermissions` e
+`checkUserSpecificRole` são chamados do `LicenseManager` (ambos propagam via `statusToError` para o
+`catch` logado do `helper.ts`), e `changeToAnonymousUser` não tem chamador no repositório. Por isso
+ficaram no fim da lista.
+
+## Verificado e considerado adequado
+
+Registrado aqui para não ser reaberto em auditorias futuras:
+
+- **`node/directives/withSession.ts:26`** — o `.catch(() => null)` é deliberado e está documentado no
+  próprio código: foi trocado por `SessionMetric` justamente por volume de log.
+- **`node/resolvers/Mutations/Users.ts:80,149,177,222`** — tratam um caso conhecido (entrada
+  duplicada, status < 400) e dão `throw error`, caindo nos callers que logam.
+- **`node/resolvers/Routes/index.ts:249`** — o early return para usuário sem `orgId` é o caminho
+  normal de todo shopper B2C; logar ali seria ruído.
+- **`node/resolvers/Routes/index.ts` (`checkPermissions`, `setProfile`)** — cobertura boa, com
+  `logger.warn` / `logger.error` em cada branch de falha e contexto suficiente (e-mail, `roleId`,
+  `costId`).
+- **`node/directives/helper.ts`** — os três catches da validação de token logam com `warn` + `err`.
+- **`node/metrics/session.ts` e `node/metrics/auth.ts`** — falha de envio de métrica é logada.
+
+## Correções sugeridas
+
+### 1. `Queries/Users.ts:592` e `:607` — degradação silenciosa de permissões
+
+Achado mais grave. `checkUserPermission` sempre chama essa função com `skipError: true`, então um
+usuário que perde acesso não gera nenhuma linha de log.
+
+```typescript
+  if (!userData.length) {
+    logger.warn({
+      email,
+      message: 'getRoleAndPermissionsByEmail-userNotFound-degraded',
+      module,
+    })
+
+    return defaultResponse
+  }
+
+  // ...
+
+  if (!userRole) {
+    logger.warn({
+      email,
+      message: 'getRoleAndPermissionsByEmail-roleNotFound-degraded',
+      roleId: userData[0].roleId,
+    })
+
+    return defaultResponse
+  }
+```
+
+### 2. `Mutations/Users.ts:135` — `getUser` engole falha do MasterData
+
+A função não recebe `ctx`, então o `logger` precisa entrar como parâmetro:
+
+```typescript
+export const getUser = async ({
+  masterdata,
+  logger,
+  params: { email, id, userId },
+}: any) => {
+  // ...
+    .catch((error: any) => {
+      logger?.error({
+        error,
+        message: 'getUser.searchDocumentsError',
+        id: id ?? userId,
+        email,
+      })
+
+      return null
+    })
+}
+```
+
+Nos três call sites (`addOrganizationToUser:457`, `addCostCenterToUser:510`,
+`setActiveUserByOrganization:599`), passar `logger` e mover o `throw new Error('User not found')`
+para dentro do `try` — ou logar antes de lançar. Hoje esse throw sai da função sem registro algum.
+
+### 3. `Queries/Users.ts:750` — impersonation
+
+```typescript
+    const userData: any = await profileSystem
+      .getProfileInfo(profile.id.value)
+      .catch((error: any) => {
+        logger.error({
+          error,
+          message: 'checkImpersonation.getProfileInfoError',
+          profileId: profile.id.value,
+        })
+
+        return null
+      })
+```
+
+### 4. `directives/withUserPermissions.ts:24`
+
+O mais consistente é replicar o que `withSession.ts` já faz: destruturar `logger` de
+`context.clients` e emitir `SessionMetric` após o `.catch(() => null)`, para que os dois directives
+tenham a mesma visibilidade sobre sessão ausente.
+
+### 5. `Queries/Settings.ts:79`
+
+```typescript
+  const roles: any = await syncRoles(ctx).catch((error) => {
+    logger.error({
+      error,
+      message: 'getAppSettings.syncRolesError',
+    })
+
+    return []
+  })
+```
+
+### 6. `Queries/Roles.ts:59`
+
+Trocar `throw new Error(error)` por `throw error` preserva stack e response, e faz o `logger.error`
+de `getRole` gravar o erro real. O mesmo padrão aparece em `Users.ts:127,807,877,932` e
+`Settings.ts:72`, mas nesses casos o log já aconteceu antes do rethrow, então só o de `Roles.ts`
+degrada o registro.
+
+### 7. `utils/metrics/changeTeam.ts:54`
+
+Alinhar com `metrics/session.ts`, recebendo o logger:
+
+```typescript
+export const sendChangeTeamMetric = async (
+  logger: Logger,
+  metricParams: ChangeTeamParams
+) => {
+  try {
+    await sendMetric(buildMetric(metricParams))
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'Unable to send change team metric',
+    })
+  }
+}
+```
+
+O call site em `Mutations/Users.ts:696` passa a ser `sendChangeTeamMetric(logger, metricParams)`.
+
+### 8, 9 e 10
+
+Baixa prioridade. O item 8 tem impacto pequeno, e os itens 9 e 10 são código sem chamador — vale
+revisitar se e quando esses métodos voltarem a ser usados.
+
+## Metodologia
+
+Pré-scan por regex (`entry points`, `catch`, chamadas de log e nível detectado) sobre os 45 arquivos
+`.ts` de `node/`, seguido de leitura do contexto em torno de cada ponto sinalizado para julgar em
+uma de três categorias:
+
+- **missing** — nenhuma chamada de log no caminho de falha.
+- **insufficient** — existe log, mas sem objeto de erro, sem identificador, ou em um canal que não
+  chega ao índice estruturado.
+- **covered** — log com contexto real em qualquer nível razoável. `warn` em falha esperada e tratada
+  conta como coberto tanto quanto `error`.

--- a/docs/log-coverage-audits/README.md
+++ b/docs/log-coverage-audits/README.md
@@ -8,12 +8,14 @@ nenhum log — ou por gerar um log sem contexto suficiente para debug.
 
 | Data | Escopo | Commit | Score | Relatório |
 |---|---|---|---|---|
+| 2026-08-21 | `node/` | `c3c6dbe` | 87/104 ≈ 84% | [2026-08-21-log-coverage-audit-c3c6dbe.md](./2026-08-21-log-coverage-audit-c3c6dbe.md) — commit posterior ao das duas primeiras; `Routes/index.ts` e `Queries/Users.ts` mudaram no meio |
 | 2026-08-21 | `node/` | `508bff6` | 86/112 ≈ 77% | [2026-08-21-log-coverage-audit-review.md](./2026-08-21-log-coverage-audit-review.md) — revisão independente do mesmo commit |
 | 2026-08-21 | `node/` | `508bff6` | 85/95 ≈ 89% | [2026-08-21-log-coverage-audit.md](./2026-08-21-log-coverage-audit.md) |
 
 ## Convenções
 
-- Um arquivo por auditoria, nomeado `YYYY-MM-DD-log-coverage-audit.md`.
+- Um arquivo por auditoria, nomeado `YYYY-MM-DD-log-coverage-audit.md`. Quando houver mais de uma
+  auditoria no mesmo dia, sufixar com o commit auditado (`-<short-sha>.md`) para desambiguar.
 - Registrar sempre o commit auditado, para que o score seja reproduzível e os números de linha
   façam sentido depois.
 - Além dos achados, manter a seção "Verificado e considerado adequado". Ela evita que decisões

--- a/docs/log-coverage-audits/README.md
+++ b/docs/log-coverage-audits/README.md
@@ -1,0 +1,25 @@
+# Auditorias de cobertura de logs
+
+Histórico das auditorias de cobertura de logs do `storefront-permissions`. Cada auditoria mapeia os
+caminhos de erro do serviço e aponta onde uma falha de produção passaria despercebida por não gerar
+nenhum log — ou por gerar um log sem contexto suficiente para debug.
+
+## Histórico
+
+| Data | Escopo | Commit | Score | Relatório |
+|---|---|---|---|---|
+| 2026-08-21 | `node/` | `508bff6` | 86/112 ≈ 77% | [2026-08-21-log-coverage-audit-review.md](./2026-08-21-log-coverage-audit-review.md) — revisão independente do mesmo commit |
+| 2026-08-21 | `node/` | `508bff6` | 85/95 ≈ 89% | [2026-08-21-log-coverage-audit.md](./2026-08-21-log-coverage-audit.md) |
+
+## Convenções
+
+- Um arquivo por auditoria, nomeado `YYYY-MM-DD-log-coverage-audit.md`.
+- Registrar sempre o commit auditado, para que o score seja reproduzível e os números de linha
+  façam sentido depois.
+- Além dos achados, manter a seção "Verificado e considerado adequado". Ela evita que decisões
+  deliberadas — como trocar log por métrica em caminho de alto volume — sejam reabertas na próxima
+  auditoria.
+- O score é `covered / (covered + missing + insufficient)` sobre os caminhos de erro e decisão
+  julgados. Caminhos triviais e sem efeito colateral ficam fora do denominador.
+- Scores só são comparáveis entre auditorias que contam o denominador da mesma forma. Registrar no
+  relatório qual é a unidade contada (bloco de `catch` vs. local que precisa de log).


### PR DESCRIPTION
## O que é

Adiciona `docs/log-coverage-audits/`, com duas auditorias independentes dos caminhos de erro de `node/` feitas sobre o commit `508bff6`, mais um README com o histórico e as convenções.

São **só documentos** — nenhuma mudança de código neste PR. A intenção é dupla:

1. Dar rastreabilidade aos caminhos de falha silenciosa que ainda estão abertos, cada um com arquivo, linha e um trecho de correção sugerido no estilo de logging que o repo já usa.
2. Registrar as decisões **deliberadas** de logging na seção "Verificado e considerado adequado", para que não sejam reabertas a cada revisão. O caso mais claro é o `.catch(() => null)` de `directives/withSession.ts:26`, que foi trocado por `SessionMetric` justamente por volume de log.

## Achados

A camada de autenticação (`directives/helper.ts` e os quatro directives de acesso) está bem instrumentada: todo caminho de negação loga `warn` com o conjunto completo de `metricFields`. O mesmo vale para praticamente todo resolver de mutation.

O achado mais relevante é que **`setProfile` não registra o erro quando uma das chamadas a clientes externos falha**. No commit auditado, seis chamadas dentro dele não tinham `.catch()` e a função não tinha `try/catch` externo — uma indisponibilidade do `b2b-organizations-graphql` derrubava todo `setProfile` sem uma linha de log do serviço.

## Atenção: o achado principal mudou de forma no master

O commit auditado está **35 commits atrás do `master`**, que reescreveu `Routes/index.ts`. Reconferi antes de abrir o PR e registrei na seção "Nota sobre o master":

- O `setProfile` do `master` agora envolve cada chamada em `timedSetProfile` (`Routes/index.ts:49`). O `catch` desse wrapper (`:75`) loga em `logger.debug` com `failed: true`, **sem o objeto `error`**, e relança. O passo que falhou ficou identificável; o erro em si, não — e `debug` normalmente é filtrado em produção.
- `setProfile` continua sem `try/catch` no nível superior, e `Routes.appSettings` / `services/appSettingsCache.ts:22` continuam sem guarda.

Ou seja, o achado **continua aberto no `master`**, só com outra forma. A correção mais direta hoje é o `catch` do `timedSetProfile` logar `logger.error({ error, message: 'setProfile.stepFailed', step })` antes do `throw`, mais o `try/catch` externo.

Os números de linha dos dois relatórios valem para `508bff6` e estão declarados como tal no cabeçalho de cada um.

## Sobre a diferença de score (89% vs. 77%)

Não é regressão de cobertura, e não é só granularidade. O lado **coberto** das duas auditorias praticamente coincide (85 e 86) — as duas acharam o mesmo conjunto de caminhos instrumentados.

A primeira auditoria mistura duas unidades no denominador: fechou `85 + 10 = 95`, contando os cobertos um por um mas os achados como linhas de tabela agrupadas. Várias daquelas linhas cobrem vários locais (o `LicenseManager` é uma linha com 6 catches, o `getUser` é uma linha com o `.catch` mais 3 callers), e expandidas somam 21 locais, não 10. Normalizada para a mesma unidade, ela daria **~80%**, não 89%.

A seção "Reconciliação dos scores" do relatório de revisão mostra a aritmética fechando: 21 locais, menos 1 inválido, mais os 6 dos achados novos, dá os 26 daqui. Deixei isso explícito para que a próxima auditoria não leia a queda como piora.

## Notas de revisão

- Os dois relatórios são do **mesmo commit**; o segundo é uma contraprova independente do primeiro. Eles coincidem em 8 dos 10 achados originais e divergem em 3 pontos, todos listados na seção "Divergências da auditoria anterior".
- A divergência que mais importa: o primeiro relatório aponta `Queries/Users.ts:592` como o achado mais grave, mas aquele branch é inalcançável (`getUserByEmail` sempre retorna um array de um elemento) e o caso de usuário não encontrado **já é logado** em `getActiveUserByEmail:168`. Sobra apenas `:607`.
- Mantive o primeiro relatório intacto em vez de corrigi-lo, para preservar o histórico.

## Test plan

Não se aplica — mudança exclusivamente de documentação, sem alteração em `node/`.