### PR TITLE
chore: instalar o gate de cobertura de logs no CI

### DIFF
--- a/.github/workflows/log-coverage.yml
+++ b/.github/workflows/log-coverage.yml
@@ -1,0 +1,72 @@
+name: Log coverage
+
+# Blocking gate: a PR that touches audited code must carry an up-to-date report
+# under docs/log-coverage/reports/pr-<number>/. The score itself does not gate —
+# a regression is a review signal, not a failure.
+#
+# Runs on every PR on purpose, with no paths filter: a required status check that
+# gets skipped by a paths filter leaves the PR waiting forever on a check that
+# never reports. Docs-only PRs run and pass without needing a report.
+'on':
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  log-coverage:
+    name: Log coverage
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth 0 so the base baseline and the merge-base diff are readable.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      # Blocking: a green gate on top of a broken scorer means nothing. Invoked
+      # directly rather than through make, so the gate works in repos with no
+      # Makefile.
+      - name: Test the scorer
+        working-directory: scripts/log_coverage
+        run: python3 -m unittest discover -p 'test_*.py'
+      # Tolerates failure so the comment below still gets posted; the verdict is
+      # re-raised in the final step.
+      - name: Check the committed report
+        id: audit
+        continue-on-error: true
+        run: |
+          python3 scripts/log_coverage/audit.py check \
+            --pr "${{ github.event.pull_request.number }}" \
+            --baseline-ref "origin/${{ github.base_ref }}" \
+            --diff-ref "origin/${{ github.base_ref }}" \
+            --markdown-out comment.md \
+            --strict
+          cat comment.md >> "$GITHUB_STEP_SUMMARY"
+      # Commenting fails on fork PRs, where GITHUB_TOKEN is read-only. The step
+      # summary above still carries the report, so that must not fail the job.
+      - name: Post or update the PR comment
+        continue-on-error: true
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          REPO: '${{ github.repository }}'
+          PR: '${{ github.event.pull_request.number }}'
+        run: |
+          [ -f comment.md ] || exit 0
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- log-coverage-report -->")) | .id' \
+            | head -n 1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -F body=@comment.md
+          else
+            gh api -X POST "repos/$REPO/issues/$PR/comments" -F body=@comment.md
+          fi
+      - name: Require an up-to-date report
+        if: steps.audit.outcome == 'failure'
+        run: |
+          echo "::error::The log-coverage report for this PR is missing or stale."
+          echo "Run: make log-coverage-report PR=${{ github.event.pull_request.number }}"
+          echo "Then commit docs/log-coverage/reports/ and docs/log-coverage/baseline.json."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .qodo
 .cursor
 .claude
+__pycache__/
+*.py[cod]

--- a/.log-coverage.json
+++ b/.log-coverage.json
@@ -1,0 +1,18 @@
+{
+  "scope": ["node/**/*.ts"],
+  "exclude": [
+    "__tests__",
+    "__mocks__",
+    "node_modules",
+    "dist",
+    "build",
+    "typings",
+    "typings.d.ts"
+  ],
+  "baseline": "docs/log-coverage/baseline.json",
+  "reportsDir": "docs/log-coverage/reports",
+  "judgedAuditGlobs": ["docs/log-coverage-audits/20*.md"],
+  "reportTriggers": ["scripts/log_coverage/audit.py"],
+  "reportCommand": "make log-coverage-report PR={pr}",
+  "docsPath": "docs/log-coverage/README.md"
+}

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ log-coverage: ## Print the log-coverage score and open findings
 log-coverage-report: ## Write the report for a PR: make log-coverage-report PR=123
 	@[ -n "$(PR)" ] || { echo "usage: make log-coverage-report PR=<number>"; exit 1; }
 	python3 scripts/log_coverage/audit.py report --pr $(PR)
-	npx prettier --write "docs/log-coverage/baseline.json" \
-	  "docs/log-coverage/reports/pr-$(PR)/metrics.json"
 
 log-coverage-test: ## Run the log-coverage scorer unit tests
 	cd scripts/log_coverage && python3 -m unittest discover -p 'test_*.py'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: log-coverage log-coverage-report log-coverage-test
+
+log-coverage: ## Print the log-coverage score and open findings
+	python3 scripts/log_coverage/audit.py scan --format text
+
+log-coverage-report: ## Write the report for a PR: make log-coverage-report PR=123
+	@[ -n "$(PR)" ] || { echo "usage: make log-coverage-report PR=<number>"; exit 1; }
+	python3 scripts/log_coverage/audit.py report --pr $(PR)
+	npx prettier --write "docs/log-coverage/baseline.json" \
+	  "docs/log-coverage/reports/pr-$(PR)/metrics.json"
+
+log-coverage-test: ## Run the log-coverage scorer unit tests
+	cd scripts/log_coverage && python3 -m unittest discover -p 'test_*.py'

--- a/docs/log-coverage/README.md
+++ b/docs/log-coverage/README.md
@@ -39,7 +39,8 @@ make log-coverage-test               # testes do próprio scorer
 ```
 
 Requer `python3`. O relatório sai em `reports/pr-<número>/` e precisa ser commitado junto com o resto
-do PR.
+do PR. A formatação do JSON gerado fica por conta do `lint-staged` no pre-commit; o `check` compara
+JSON parseado, não bytes, então reformatar é inofensivo.
 
 ## O que trava o merge e o que não trava
 

--- a/docs/log-coverage/README.md
+++ b/docs/log-coverage/README.md
@@ -1,0 +1,72 @@
+# Gate de cobertura de logs
+
+Este diretório guarda a métrica **determinística** de cobertura de logs do `storefront-permissions`:
+o baseline commitado e um relatório por PR. Quem produz esses arquivos é
+`scripts/log_coverage/audit.py`, e o workflow `Log coverage` os verifica em cada Pull Request.
+
+## O que a métrica mede
+
+De todos os caminhos de tratamento de falha do escopo auditado — blocos `catch` e callbacks passados
+para `.catch(...)` — quantos registram a falha em log. O score é `covered / total`.
+
+Cada handler recebe exatamente uma classificação:
+
+| Status | Significado |
+|---|---|
+| `covered` | Loga a falha **e** repassa o objeto de erro, ou faz rethrow |
+| `insufficient` | Loga, mas sem o objeto de erro — só uma mensagem |
+| `missing` | Não loga e não faz rethrow. A falha é silenciosa |
+
+O escopo está em `.log-coverage.json` e hoje cobre `node/**/*.ts`, exceto testes, mocks e typings.
+
+## Esta não é a mesma métrica das auditorias julgadas
+
+As auditorias em [`../log-coverage-audits/`](../log-coverage-audits/) foram feitas por um modelo lendo
+o código, e contam também abortos de validação, early returns e contexto que atravessa funções. Esta
+métrica não conta nada disso: ela casa estrutura de código com regex e só enxerga `catch` e
+`.catch()`.
+
+Ou seja, o número daqui é **de resolução mais baixa de propósito**, em troca de ser reproduzível
+byte a byte. Serve para travar CI e acompanhar tendência. Para decidir *o que* corrigir, use a
+auditoria julgada. Um score não corrige nem substitui o outro.
+
+## Rodando localmente
+
+```bash
+make log-coverage                    # score e achados em aberto
+make log-coverage-report PR=123      # escreve o baseline e o relatório do PR 123
+make log-coverage-test               # testes do próprio scorer
+```
+
+Requer `python3`. O relatório sai em `reports/pr-<número>/` e precisa ser commitado junto com o resto
+do PR.
+
+## O que trava o merge e o que não trava
+
+- **Trava:** PR que mexe em arquivo do escopo (ou em `scripts/log_coverage/audit.py`) sem trazer o
+  relatório atualizado daquele PR.
+- **Trava:** teste do scorer quebrado.
+- **Não trava:** o score cair. Uma regressão vira comentário no PR para o revisor decidir, não
+  falha de CI. Travar no número convida a burlar o número.
+- **Não trava:** PR só de documentação ou configuração — roda, passa, e não exige relatório.
+
+## Suprimindo um caso legítimo
+
+Quando engolir a falha é de fato o comportamento correto, marque no código:
+
+```typescript
+try {
+  await optionalTelemetry(payload)
+} catch {
+  // log-coverage-ignore: telemetria é best-effort e não pode afetar a request
+}
+```
+
+O handler sai do denominador — não entra como `covered`, ou seja, suprimir não infla o score. Sempre
+escreva o motivo depois do marcador: supressão sem justificativa é indistinguível de falha silenciosa
+que alguém cansou de ver.
+
+## Mudou o escopo?
+
+Mudar `scope` muda o score. Trate como reset de baseline: regenere o baseline no mesmo PR e diga isso
+na descrição, senão o próximo PR herda um salto inexplicado.

--- a/docs/log-coverage/baseline.json
+++ b/docs/log-coverage/baseline.json
@@ -1,0 +1,759 @@
+{
+  "schemaVersion": 1,
+  "scope": [
+    "node/**/*.ts"
+  ],
+  "score": {
+    "covered": 68,
+    "insufficient": 0,
+    "missing": 25,
+    "total": 93,
+    "percent": 73.1
+  },
+  "handlers": [
+    {
+      "id": "bd5cd0d24b0e",
+      "file": "node/clients/checkout.ts",
+      "line": 270,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "4396a56f5798",
+      "file": "node/clients/checkout.ts",
+      "line": 276,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(err) => { // This endpoint is expected to return a redirect to // the user, so we can ignore the error if it is a 3xx if (!err.response || "
+    },
+    {
+      "id": "bd5cd0d24b0e-2",
+      "file": "node/clients/checkout.ts",
+      "line": 328,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-3",
+      "file": "node/clients/checkout.ts",
+      "line": 339,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-4",
+      "file": "node/clients/checkout.ts",
+      "line": 354,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-5",
+      "file": "node/clients/checkout.ts",
+      "line": 363,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-6",
+      "file": "node/clients/checkout.ts",
+      "line": 380,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-7",
+      "file": "node/clients/checkout.ts",
+      "line": 391,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "c327fec47ebb",
+      "file": "node/directives/helper.ts",
+      "line": 70,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "// noop so we leave hasValidAdminToken as false logger.warn({ message: 'Error validating admin token', err, })"
+    },
+    {
+      "id": "5fa23d5da3f5",
+      "file": "node/directives/helper.ts",
+      "line": 157,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "// noop so we leave hasValidApiToken as false logger.warn({ message: 'Error validating API token', err, })"
+    },
+    {
+      "id": "8fb0d9a3bf82",
+      "file": "node/directives/helper.ts",
+      "line": 210,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "// noop so we leave hasValidStoreToken as false logger.warn({ message: 'Error validating store token:', err, })"
+    },
+    {
+      "id": "0180e6f5bca9",
+      "file": "node/directives/withSession.ts",
+      "line": 26,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "75b467ee4a9e",
+      "file": "node/directives/withUserPermissions.ts",
+      "line": 24,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "36d3064190e9",
+      "file": "node/metrics/auth.ts",
+      "line": 43,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `Error to send metrics from auth metric`, })"
+    },
+    {
+      "id": "94183c3ceaf3",
+      "file": "node/metrics/session.ts",
+      "line": 38,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `Error to send metrics from session metric`, })"
+    },
+    {
+      "id": "fab72460c514",
+      "file": "node/resolvers/Mutations/Profiles.ts",
+      "line": 32,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.saveProfile-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "9b55c65b24f0",
+      "file": "node/resolvers/Mutations/Profiles.ts",
+      "line": 52,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.deleteProfile-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "5396d046a647",
+      "file": "node/resolvers/Mutations/Roles.ts",
+      "line": 39,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Roles.saveRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "d2c047e51623",
+      "file": "node/resolvers/Mutations/Roles.ts",
+      "line": 139,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Roles.deleteRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "253da035dee7",
+      "file": "node/resolvers/Mutations/Settings.ts",
+      "line": 12,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "574b7c882e43",
+      "file": "node/resolvers/Mutations/Settings.ts",
+      "line": 23,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'sessionWatcher.saveSessionWatcherError', }) return false }"
+    },
+    {
+      "id": "ae16bd12d47d",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 35,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setChangeSession.error', attempt: countRetry, }) if (countRetry < MAX_RETRY) { countRetry++ const backoff = "
+    },
+    {
+      "id": "c46cf491b620",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 80,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response?.data?.Message === 'duplicated entry') { return masterdata .searchDocuments({ dataEntity: CUSTOMER_SCHE"
+    },
+    {
+      "id": "dab6718caaa2",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 135,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "2369669c7875",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 149,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status < 400) { return { DocumentId: id, } } throw error }"
+    },
+    {
+      "id": "2369669c7875-2",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 177,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status < 400) { return { DocumentId: id, } } throw error }"
+    },
+    {
+      "id": "2369669c7875-3",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 222,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status < 400) { return { DocumentId: id, } } throw error }"
+    },
+    {
+      "id": "351ceeedb23a",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 285,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'addUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "a11e13da969e",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 314,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'updateUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "0bed6e7debda",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 350,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status >= 400) { throw error } logger.error({ error, message: 'deleteUserProfile.error', }) return [] }"
+    },
+    {
+      "id": "833da6f40ee5",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 370,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'deleteUserProfile.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "24079aadf3d4",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 395,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'deleteUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "2cbc7d25dd06",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 421,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'impersonateUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "e93501cf9034",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 488,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'addOrganizationToUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "d9ddda1722e7",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 542,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'addCostCenterToUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "6f1f96f1e593",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 572,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { logger.error({ error, message: 'orders-getSession-error', }) return null }"
+    },
+    {
+      "id": "f2b57f328076",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 628,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setActiveUserById.error', })"
+    },
+    {
+      "id": "0305b2041296",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 706,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'updateCurrentOrganization.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "c10dd5d3150d",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 784,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setCurrentPriceTable.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "b6f6339a7ada",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 817,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'removeB2BSessionData.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "45b57f4e2b71",
+      "file": "node/resolvers/Queries/Profiles.ts",
+      "line": 21,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getProfile-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "3c22971c801e",
+      "file": "node/resolvers/Queries/Profiles.ts",
+      "line": 49,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getProfileByRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "a3558a4a328f",
+      "file": "node/resolvers/Queries/Profiles.ts",
+      "line": 83,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.listProfiles-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "345b7b335820",
+      "file": "node/resolvers/Queries/Roles.ts",
+      "line": 43,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "if (error?.response?.status === 404) { const options: any = { dataEntity: config.name, fields: ['id', 'name', 'features', 'locked', 'slug'],"
+    },
+    {
+      "id": "63a74462010a",
+      "file": "node/resolvers/Queries/Roles.ts",
+      "line": 76,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Roles.getRole', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "66b4972c82e5",
+      "file": "node/resolvers/Queries/Roles.ts",
+      "line": 109,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error: e, message: 'Roles.listRoles', }) return { status: 'error', message: e }"
+    },
+    {
+      "id": "b92a877031ba",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 21,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "bc50c4315b34",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 51,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: ErrorResponse) => { if (error.response.status !== 304) { throw error } return true }"
+    },
+    {
+      "id": "c54b662577f9",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 65,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { if (error.response.status !== 304) { logger.error({ error, message: 'getAppSettings-error', }) throw new Error(error) } }"
+    },
+    {
+      "id": "8c36b7d05799",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 79,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => []"
+    },
+    {
+      "id": "b92a877031ba-2",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 94,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "966dbe646c30",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 100,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'getSessionWatcher.getSessionWatcherError', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "f237ef2f08ac",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 123,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getAllUsersByEmail-error', }) throw new Error(error)"
+    },
+    {
+      "id": "4e4169fdf815",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 180,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getActiveUserByEmail-error`, }) return { message: error, status: 'error' }"
+    },
+    {
+      "id": "00c143a9c428",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 232,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUserById-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "00c143a9c428-2",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 291,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUserById-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "c5168f902959",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 350,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUser-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "125c4d8c7d45",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 385,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUserByRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "a300f63ef2af",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 456,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.listUsers-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "5c34090523c8",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 545,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.listUsersPaginated-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "0eae5b7bdd33",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 700,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ error, message: 'checkUserPermission-getAppSettingsError' }) return {} as Record<string, unknown> }"
+    },
+    {
+      "id": "e2c74d1ca23e",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 789,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "232e631737c6",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 839,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getUsersByEmail-error`, }) throw new Error(error)"
+    },
+    {
+      "id": "d41bf8fc6a64",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 869,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getOrganizationsByEmail-error`, }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "aae20d400921",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 908,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'getOrganizationsPaginatedByEmail-error', }) throw new Error(error)"
+    },
+    {
+      "id": "232e631737c6-2",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 964,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getUsersByEmail-error`, }) throw new Error(error)"
+    },
+    {
+      "id": "db857445bec5",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 75,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "const now = Date.now() const stepTiming: SetProfileStepTiming = { step, durationMs: now - start, failed: true, totalMs: now - timing.t0, } s"
+    },
+    {
+      "id": "2336d2100b89",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 317,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ message: 'setProfile.getUserError', error }) logSetProfileStep('impersonate.b2b.error')"
+    },
+    {
+      "id": "9d8e87e1b707",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 343,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ message: 'setProfile.getUserByEmailError', error }) }"
+    },
+    {
+      "id": "bf83e3d8349f",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 378,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.graphqlGetOrganizationById', }) }"
+    },
+    {
+      "id": "dae5b887c3f5",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 433,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setProfile.graphqlGetOrganizationById', })"
+    },
+    {
+      "id": "19b6cac6de0b",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 457,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.getUserOrganizationsData', }) return { validCostCenterId: null, activeOrganization: "
+    },
+    {
+      "id": "393b20e908d7",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 497,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ error, message: 'setProfile.setActiveUserByOrganizationError', }) }"
+    },
+    {
+      "id": "225a73e1d8c3",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 706,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateSalesChannel', }) }"
+    },
+    {
+      "id": "92d153b62896",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 741,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setProfile.clearCart', })"
+    },
+    {
+      "id": "9599fdf29746",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 777,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setProfile.getRegionId', }) logSetProfileStep('getRegionId.error')"
+    },
+    {
+      "id": "3479ef9b062c",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 805,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateOrderFormMarketingDataError', }) }"
+    },
+    {
+      "id": "96db79a4a00b",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 827,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateOrderFormShippingError', }) }"
+    },
+    {
+      "id": "6ed3f0638700",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 879,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateOrderFormProfileError', }) }"
+    },
+    {
+      "id": "70a299098b59",
+      "file": "node/resolvers/Routes/utils/index.ts",
+      "line": 137,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ message: 'setProfile.getUserByIdError', error }) }"
+    },
+    {
+      "id": "9465ca01abdf",
+      "file": "node/resolvers/Routes/utils/index.ts",
+      "line": 248,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ error, message: 'Failed to fetch page', page }) return null }"
+    },
+    {
+      "id": "57a3e954d3e7",
+      "file": "node/resolvers/Routes/utils/index.ts",
+      "line": 301,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'getUserOrganizationsData.error', email, }) return { validCostCenterId: null, activeOrganization: null }"
+    },
+    {
+      "id": "b267ce05a1c7",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 29,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return null }"
+    },
+    {
+      "id": "aaaa650a1ee0",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 50,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "3ff9a5d94e66",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 58,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => false"
+    },
+    {
+      "id": "9e9fcba79ad1",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 74,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return false }"
+    },
+    {
+      "id": "faea66114577",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 119,
+      "kind": "catch-block",
+      "status": "missing",
+      "snippet": "return false"
+    },
+    {
+      "id": "faea66114577-2",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 137,
+      "kind": "catch-block",
+      "status": "missing",
+      "snippet": "return false"
+    },
+    {
+      "id": "b356b3b9e7c6",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 143,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "b356b3b9e7c6-2",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 147,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "b356b3b9e7c6-3",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 151,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "b356b3b9e7c6-4",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 155,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "ec16092a6f26",
+      "file": "node/utils/metrics/changeTeam.ts",
+      "line": 53,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "console.warn('Unable to log metrics', error)"
+    }
+  ]
+}

--- a/docs/log-coverage/reports/pr-206/metrics.json
+++ b/docs/log-coverage/reports/pr-206/metrics.json
@@ -1,0 +1,759 @@
+{
+  "schemaVersion": 1,
+  "scope": [
+    "node/**/*.ts"
+  ],
+  "score": {
+    "covered": 68,
+    "insufficient": 0,
+    "missing": 25,
+    "total": 93,
+    "percent": 73.1
+  },
+  "handlers": [
+    {
+      "id": "bd5cd0d24b0e",
+      "file": "node/clients/checkout.ts",
+      "line": 270,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "4396a56f5798",
+      "file": "node/clients/checkout.ts",
+      "line": 276,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(err) => { // This endpoint is expected to return a redirect to // the user, so we can ignore the error if it is a 3xx if (!err.response || "
+    },
+    {
+      "id": "bd5cd0d24b0e-2",
+      "file": "node/clients/checkout.ts",
+      "line": 328,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-3",
+      "file": "node/clients/checkout.ts",
+      "line": 339,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-4",
+      "file": "node/clients/checkout.ts",
+      "line": 354,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-5",
+      "file": "node/clients/checkout.ts",
+      "line": 363,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-6",
+      "file": "node/clients/checkout.ts",
+      "line": 380,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "bd5cd0d24b0e-7",
+      "file": "node/clients/checkout.ts",
+      "line": 391,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "c327fec47ebb",
+      "file": "node/directives/helper.ts",
+      "line": 70,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "// noop so we leave hasValidAdminToken as false logger.warn({ message: 'Error validating admin token', err, })"
+    },
+    {
+      "id": "5fa23d5da3f5",
+      "file": "node/directives/helper.ts",
+      "line": 157,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "// noop so we leave hasValidApiToken as false logger.warn({ message: 'Error validating API token', err, })"
+    },
+    {
+      "id": "8fb0d9a3bf82",
+      "file": "node/directives/helper.ts",
+      "line": 210,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "// noop so we leave hasValidStoreToken as false logger.warn({ message: 'Error validating store token:', err, })"
+    },
+    {
+      "id": "0180e6f5bca9",
+      "file": "node/directives/withSession.ts",
+      "line": 26,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "75b467ee4a9e",
+      "file": "node/directives/withUserPermissions.ts",
+      "line": 24,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "36d3064190e9",
+      "file": "node/metrics/auth.ts",
+      "line": 43,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `Error to send metrics from auth metric`, })"
+    },
+    {
+      "id": "94183c3ceaf3",
+      "file": "node/metrics/session.ts",
+      "line": 38,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `Error to send metrics from session metric`, })"
+    },
+    {
+      "id": "fab72460c514",
+      "file": "node/resolvers/Mutations/Profiles.ts",
+      "line": 32,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.saveProfile-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "9b55c65b24f0",
+      "file": "node/resolvers/Mutations/Profiles.ts",
+      "line": 52,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.deleteProfile-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "5396d046a647",
+      "file": "node/resolvers/Mutations/Roles.ts",
+      "line": 39,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Roles.saveRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "d2c047e51623",
+      "file": "node/resolvers/Mutations/Roles.ts",
+      "line": 139,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Roles.deleteRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "253da035dee7",
+      "file": "node/resolvers/Mutations/Settings.ts",
+      "line": 12,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "574b7c882e43",
+      "file": "node/resolvers/Mutations/Settings.ts",
+      "line": 23,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'sessionWatcher.saveSessionWatcherError', }) return false }"
+    },
+    {
+      "id": "ae16bd12d47d",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 35,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setChangeSession.error', attempt: countRetry, }) if (countRetry < MAX_RETRY) { countRetry++ const backoff = "
+    },
+    {
+      "id": "c46cf491b620",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 80,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response?.data?.Message === 'duplicated entry') { return masterdata .searchDocuments({ dataEntity: CUSTOMER_SCHE"
+    },
+    {
+      "id": "dab6718caaa2",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 135,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "2369669c7875",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 149,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status < 400) { return { DocumentId: id, } } throw error }"
+    },
+    {
+      "id": "2369669c7875-2",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 177,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status < 400) { return { DocumentId: id, } } throw error }"
+    },
+    {
+      "id": "2369669c7875-3",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 222,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status < 400) { return { DocumentId: id, } } throw error }"
+    },
+    {
+      "id": "351ceeedb23a",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 285,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'addUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "a11e13da969e",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 314,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'updateUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "0bed6e7debda",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 350,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { if (error.response.status >= 400) { throw error } logger.error({ error, message: 'deleteUserProfile.error', }) return [] }"
+    },
+    {
+      "id": "833da6f40ee5",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 370,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'deleteUserProfile.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "24079aadf3d4",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 395,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'deleteUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "2cbc7d25dd06",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 421,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'impersonateUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "e93501cf9034",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 488,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'addOrganizationToUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "d9ddda1722e7",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 542,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'addCostCenterToUser.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "6f1f96f1e593",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 572,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: any) => { logger.error({ error, message: 'orders-getSession-error', }) return null }"
+    },
+    {
+      "id": "f2b57f328076",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 628,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setActiveUserById.error', })"
+    },
+    {
+      "id": "0305b2041296",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 706,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'updateCurrentOrganization.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "c10dd5d3150d",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 784,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setCurrentPriceTable.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "b6f6339a7ada",
+      "file": "node/resolvers/Mutations/Users.ts",
+      "line": 817,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'removeB2BSessionData.error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "45b57f4e2b71",
+      "file": "node/resolvers/Queries/Profiles.ts",
+      "line": 21,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getProfile-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "3c22971c801e",
+      "file": "node/resolvers/Queries/Profiles.ts",
+      "line": 49,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getProfileByRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "a3558a4a328f",
+      "file": "node/resolvers/Queries/Profiles.ts",
+      "line": 83,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.listProfiles-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "345b7b335820",
+      "file": "node/resolvers/Queries/Roles.ts",
+      "line": 43,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "if (error?.response?.status === 404) { const options: any = { dataEntity: config.name, fields: ['id', 'name', 'features', 'locked', 'slug'],"
+    },
+    {
+      "id": "63a74462010a",
+      "file": "node/resolvers/Queries/Roles.ts",
+      "line": 76,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Roles.getRole', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "66b4972c82e5",
+      "file": "node/resolvers/Queries/Roles.ts",
+      "line": 109,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error: e, message: 'Roles.listRoles', }) return { status: 'error', message: e }"
+    },
+    {
+      "id": "b92a877031ba",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 21,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "bc50c4315b34",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 51,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error: ErrorResponse) => { if (error.response.status !== 304) { throw error } return true }"
+    },
+    {
+      "id": "c54b662577f9",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 65,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { if (error.response.status !== 304) { logger.error({ error, message: 'getAppSettings-error', }) throw new Error(error) } }"
+    },
+    {
+      "id": "8c36b7d05799",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 79,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => []"
+    },
+    {
+      "id": "b92a877031ba-2",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 94,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "966dbe646c30",
+      "file": "node/resolvers/Queries/Settings.ts",
+      "line": 100,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'getSessionWatcher.getSessionWatcherError', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "f237ef2f08ac",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 123,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getAllUsersByEmail-error', }) throw new Error(error)"
+    },
+    {
+      "id": "4e4169fdf815",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 180,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getActiveUserByEmail-error`, }) return { message: error, status: 'error' }"
+    },
+    {
+      "id": "00c143a9c428",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 232,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUserById-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "00c143a9c428-2",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 291,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUserById-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "c5168f902959",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 350,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUser-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "125c4d8c7d45",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 385,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.getUserByRole-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "a300f63ef2af",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 456,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.listUsers-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "5c34090523c8",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 545,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'Profiles.listUsersPaginated-error', }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "0eae5b7bdd33",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 700,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ error, message: 'checkUserPermission-getAppSettingsError' }) return {} as Record<string, unknown> }"
+    },
+    {
+      "id": "e2c74d1ca23e",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 789,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => null"
+    },
+    {
+      "id": "232e631737c6",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 839,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getUsersByEmail-error`, }) throw new Error(error)"
+    },
+    {
+      "id": "d41bf8fc6a64",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 869,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getOrganizationsByEmail-error`, }) return { status: 'error', message: error }"
+    },
+    {
+      "id": "aae20d400921",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 908,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'getOrganizationsPaginatedByEmail-error', }) throw new Error(error)"
+    },
+    {
+      "id": "232e631737c6-2",
+      "file": "node/resolvers/Queries/Users.ts",
+      "line": 964,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: `getUsersByEmail-error`, }) throw new Error(error)"
+    },
+    {
+      "id": "db857445bec5",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 75,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "const now = Date.now() const stepTiming: SetProfileStepTiming = { step, durationMs: now - start, failed: true, totalMs: now - timing.t0, } s"
+    },
+    {
+      "id": "2336d2100b89",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 317,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ message: 'setProfile.getUserError', error }) logSetProfileStep('impersonate.b2b.error')"
+    },
+    {
+      "id": "9d8e87e1b707",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 343,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ message: 'setProfile.getUserByEmailError', error }) }"
+    },
+    {
+      "id": "bf83e3d8349f",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 378,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.graphqlGetOrganizationById', }) }"
+    },
+    {
+      "id": "dae5b887c3f5",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 433,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setProfile.graphqlGetOrganizationById', })"
+    },
+    {
+      "id": "19b6cac6de0b",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 457,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.getUserOrganizationsData', }) return { validCostCenterId: null, activeOrganization: "
+    },
+    {
+      "id": "393b20e908d7",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 497,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ error, message: 'setProfile.setActiveUserByOrganizationError', }) }"
+    },
+    {
+      "id": "225a73e1d8c3",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 706,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateSalesChannel', }) }"
+    },
+    {
+      "id": "92d153b62896",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 741,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setProfile.clearCart', })"
+    },
+    {
+      "id": "9599fdf29746",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 777,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'setProfile.getRegionId', }) logSetProfileStep('getRegionId.error')"
+    },
+    {
+      "id": "3479ef9b062c",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 805,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateOrderFormMarketingDataError', }) }"
+    },
+    {
+      "id": "96db79a4a00b",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 827,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateOrderFormShippingError', }) }"
+    },
+    {
+      "id": "6ed3f0638700",
+      "file": "node/resolvers/Routes/index.ts",
+      "line": 879,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ error, message: 'setProfile.updateOrderFormProfileError', }) }"
+    },
+    {
+      "id": "70a299098b59",
+      "file": "node/resolvers/Routes/utils/index.ts",
+      "line": 137,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.error({ message: 'setProfile.getUserByIdError', error }) }"
+    },
+    {
+      "id": "9465ca01abdf",
+      "file": "node/resolvers/Routes/utils/index.ts",
+      "line": 248,
+      "kind": "promise-catch",
+      "status": "covered",
+      "snippet": "(error) => { logger.warn({ error, message: 'Failed to fetch page', page }) return null }"
+    },
+    {
+      "id": "57a3e954d3e7",
+      "file": "node/resolvers/Routes/utils/index.ts",
+      "line": 301,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "logger.error({ error, message: 'getUserOrganizationsData.error', email, }) return { validCostCenterId: null, activeOrganization: null }"
+    },
+    {
+      "id": "b267ce05a1c7",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 29,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return null }"
+    },
+    {
+      "id": "aaaa650a1ee0",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 50,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return {} }"
+    },
+    {
+      "id": "3ff9a5d94e66",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 58,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => false"
+    },
+    {
+      "id": "9e9fcba79ad1",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 74,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "() => { return false }"
+    },
+    {
+      "id": "faea66114577",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 119,
+      "kind": "catch-block",
+      "status": "missing",
+      "snippet": "return false"
+    },
+    {
+      "id": "faea66114577-2",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 137,
+      "kind": "catch-block",
+      "status": "missing",
+      "snippet": "return false"
+    },
+    {
+      "id": "b356b3b9e7c6",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 143,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "b356b3b9e7c6-2",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 147,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "b356b3b9e7c6-3",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 151,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "b356b3b9e7c6-4",
+      "file": "node/utils/LicenseManager.ts",
+      "line": 155,
+      "kind": "promise-catch",
+      "status": "missing",
+      "snippet": "statusToError"
+    },
+    {
+      "id": "ec16092a6f26",
+      "file": "node/utils/metrics/changeTeam.ts",
+      "line": 53,
+      "kind": "catch-block",
+      "status": "covered",
+      "snippet": "console.warn('Unable to log metrics', error)"
+    }
+  ]
+}

--- a/docs/log-coverage/reports/pr-206/report.md
+++ b/docs/log-coverage/reports/pr-206/report.md
@@ -1,0 +1,77 @@
+# Log coverage — PR #206
+
+**Date:** 2026-08-21  
+**Scope:** `node/**/*.ts`  
+**Score:** 68/93 = 73.1% (missing 25, insufficient 0)
+
+Deterministic proxy metric over `try/catch` and `.catch(...)` handlers. It is not a model-judged audit score, which also weighs validation aborts and cross-function context. Judged audits: [`2026-08-21-log-coverage-audit-review.md`](../../../log-coverage-audits/2026-08-21-log-coverage-audit-review.md), [`2026-08-21-log-coverage-audit-c3c6dbe.md`](../../../log-coverage-audits/2026-08-21-log-coverage-audit-c3c6dbe.md), [`2026-08-21-log-coverage-audit.md`](../../../log-coverage-audits/2026-08-21-log-coverage-audit.md). See [`docs/log-coverage/README.md`](../../README.md).
+
+## Delta
+
+- **Baseline** (none): 0/0 = 0.0% (missing 0, insufficient 0)
+- **This branch**: 68/93 = 73.1% (missing 25, insufficient 0)
+- **Delta**: up 73.1 pp
+
+### New or regressed (25)
+
+| file:line | kind | status | body |
+|---|---|---|---|
+| `node/clients/checkout.ts:270` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:328` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:339` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:354` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:363` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:380` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:391` | promise-catch | **missing** | `statusToError` |
+| `node/directives/withSession.ts:26` | promise-catch | **missing** | `() => null` |
+| `node/directives/withUserPermissions.ts:24` | promise-catch | **missing** | `() => null` |
+| `node/resolvers/Mutations/Settings.ts:12` | promise-catch | **missing** | `() => { return {} }` |
+| `node/resolvers/Mutations/Users.ts:135` | promise-catch | **missing** | `() => null` |
+| `node/resolvers/Queries/Settings.ts:21` | promise-catch | **missing** | `() => { return {} }` |
+| `node/resolvers/Queries/Settings.ts:79` | promise-catch | **missing** | `() => []` |
+| `node/resolvers/Queries/Settings.ts:94` | promise-catch | **missing** | `() => { return {} }` |
+| `node/resolvers/Queries/Users.ts:789` | promise-catch | **missing** | `() => null` |
+| `node/utils/LicenseManager.ts:29` | promise-catch | **missing** | `() => { return null }` |
+| `node/utils/LicenseManager.ts:50` | promise-catch | **missing** | `() => { return {} }` |
+| `node/utils/LicenseManager.ts:58` | promise-catch | **missing** | `() => false` |
+| `node/utils/LicenseManager.ts:74` | promise-catch | **missing** | `() => { return false }` |
+| `node/utils/LicenseManager.ts:119` | catch-block | **missing** | `return false` |
+| `node/utils/LicenseManager.ts:137` | catch-block | **missing** | `return false` |
+| `node/utils/LicenseManager.ts:143` | promise-catch | **missing** | `statusToError` |
+| `node/utils/LicenseManager.ts:147` | promise-catch | **missing** | `statusToError` |
+| `node/utils/LicenseManager.ts:151` | promise-catch | **missing** | `statusToError` |
+| `node/utils/LicenseManager.ts:155` | promise-catch | **missing** | `statusToError` |
+
+### Resolved or removed (0)
+
+_none_
+
+## All open findings (25)
+
+| file:line | kind | status | body |
+|---|---|---|---|
+| `node/clients/checkout.ts:270` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:328` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:339` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:354` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:363` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:380` | promise-catch | **missing** | `statusToError` |
+| `node/clients/checkout.ts:391` | promise-catch | **missing** | `statusToError` |
+| `node/directives/withSession.ts:26` | promise-catch | **missing** | `() => null` |
+| `node/directives/withUserPermissions.ts:24` | promise-catch | **missing** | `() => null` |
+| `node/resolvers/Mutations/Settings.ts:12` | promise-catch | **missing** | `() => { return {} }` |
+| `node/resolvers/Mutations/Users.ts:135` | promise-catch | **missing** | `() => null` |
+| `node/resolvers/Queries/Settings.ts:21` | promise-catch | **missing** | `() => { return {} }` |
+| `node/resolvers/Queries/Settings.ts:79` | promise-catch | **missing** | `() => []` |
+| `node/resolvers/Queries/Settings.ts:94` | promise-catch | **missing** | `() => { return {} }` |
+| `node/resolvers/Queries/Users.ts:789` | promise-catch | **missing** | `() => null` |
+| `node/utils/LicenseManager.ts:29` | promise-catch | **missing** | `() => { return null }` |
+| `node/utils/LicenseManager.ts:50` | promise-catch | **missing** | `() => { return {} }` |
+| `node/utils/LicenseManager.ts:58` | promise-catch | **missing** | `() => false` |
+| `node/utils/LicenseManager.ts:74` | promise-catch | **missing** | `() => { return false }` |
+| `node/utils/LicenseManager.ts:119` | catch-block | **missing** | `return false` |
+| `node/utils/LicenseManager.ts:137` | catch-block | **missing** | `return false` |
+| `node/utils/LicenseManager.ts:143` | promise-catch | **missing** | `statusToError` |
+| `node/utils/LicenseManager.ts:147` | promise-catch | **missing** | `statusToError` |
+| `node/utils/LicenseManager.ts:151` | promise-catch | **missing** | `statusToError` |
+| `node/utils/LicenseManager.ts:155` | promise-catch | **missing** | `statusToError` |

--- a/scripts/log_coverage/audit.py
+++ b/scripts/log_coverage/audit.py
@@ -1,0 +1,1038 @@
+#!/usr/bin/env python3
+"""Deterministic log-coverage scorer for TypeScript/JavaScript repositories.
+
+Scores failure-handling paths (`try/catch` blocks and `.catch(...)` callbacks) in
+the audited scope. Every handler is classified as covered / insufficient /
+missing, and the score is `covered / total`.
+
+This is a proxy metric, and it is deterministic on purpose: the same tree always
+yields the same number, which is what makes baseline comparison meaningful. It is
+deliberately *not* the same number a model produces when it judges log coverage
+by hand, which also weighs validation aborts and cross-function context.
+
+Everything repository-specific lives in `.log-coverage.json` at the repo root, so
+this file is identical across apps. See the `log-coverage-setup` skill for the
+config contract.
+
+Subcommands:
+  scan     Scan the scope and print metrics (json or text).
+  report   Write the per-PR report folder and refresh the baseline (run locally).
+  check    Emit a markdown PR-comment body comparing head against the base
+           baseline, and gate on the committed report. With `--strict`, exits
+           non-zero when a required report is missing or stale.
+"""
+from __future__ import annotations
+
+import argparse
+import functools
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from datetime import date
+from pathlib import Path, PurePosixPath
+
+CONFIG_FILENAME = ".log-coverage.json"
+
+# Everything below is repository-specific and is replaced by `configure()` from
+# .log-coverage.json before any command runs. They stay module-level because the
+# whole call graph reads them, and because tests patch them directly.
+REPO_ROOT = Path.cwd()
+SCOPE: tuple[str, ...] = ()
+EXCLUDED_PARTS: tuple[str, ...] = ("__tests__", "node_modules", "dist", "build")
+BASELINE_PATH = Path("docs/log-coverage/baseline.json")
+REPORTS_DIR = Path("docs/log-coverage/reports")
+JUDGED_AUDIT_GLOBS: tuple[str, ...] = ()
+# Paths that demand a fresh report even though they are not audited sources —
+# typically this script itself, since editing it can move the metrics.
+REPORT_TRIGGERS: tuple[str, ...] = ()
+
+CONFIG_DEFAULTS = {
+    "exclude": list(EXCLUDED_PARTS),
+    "baseline": BASELINE_PATH.as_posix(),
+    "reportsDir": REPORTS_DIR.as_posix(),
+    "judgedAuditGlobs": [],
+    "reportTriggers": [],
+    # Shown to developers in the PR comment. `{pr}` is substituted. Repos with the
+    # Makefile targets installed override this with `make log-coverage-report PR={pr}`.
+    "reportCommand": "python3 scripts/log_coverage/audit.py report --pr {pr}",
+    # Optional in-repo doc to link from the comment. Omitted when empty.
+    "docsPath": "",
+}
+
+REPORT_COMMAND = CONFIG_DEFAULTS["reportCommand"]
+DOCS_PATH = ""
+
+
+def report_command(pr: str | None) -> str:
+    return REPORT_COMMAND.format(pr=pr or "<number>")
+
+SCHEMA_VERSION = 1
+SUPPRESSION_MARKER = "log-coverage-ignore"
+# Lets the workflow find and update its own comment instead of stacking new ones.
+COMMENT_MARKER = "<!-- log-coverage-report -->"
+
+REPORT_NOT_REQUIRED = "not-required"
+REPORT_MISSING = "missing"
+REPORT_STALE = "stale"
+REPORT_FRESH = "fresh"
+BLOCKING_REPORT_STATES = (REPORT_MISSING, REPORT_STALE)
+
+CATCH_BLOCK_RE = re.compile(r"\bcatch\s*(?:\([^()]*\)\s*)?\{")
+DOT_CATCH_RE = re.compile(r"\.\s*catch\s*\(")
+
+# `ctx.vtex.logger.warn(` matches on the `logger.warn(` tail: `\b` holds between
+# the dot and the identifier.
+LOG_CALL_RE = re.compile(
+    r"\b(?:console|log|logger|[A-Za-z_$][\w$]*[Ll]og(?:ger)?)"
+    r"\s*\.\s*(info|warn|warning|error|debug|trace|fatal)\s*\("
+)
+ERROR_CONTEXT_RE = re.compile(
+    r"\berr(?:or)?\w*\b|\bexception\b|\bstack\b|\.message\b", re.IGNORECASE
+)
+RETHROW_RE = re.compile(r"\bthrow\b")
+
+# A `/` opens a regex literal only where a value cannot already have ended.
+REGEX_PREV_KEYWORDS = frozenset(
+    (
+        "return",
+        "typeof",
+        "case",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "throw",
+        "do",
+        "else",
+        "yield",
+        "await",
+    )
+)
+REGEX_PREV_PUNCTUATION = frozenset("(,=:[!&|?{};+-*/%~^<>")
+
+STATUS_COVERED = "covered"
+STATUS_INSUFFICIENT = "insufficient"
+STATUS_MISSING = "missing"
+
+
+# --------------------------------------------------------------------------- #
+# Source masking
+# --------------------------------------------------------------------------- #
+
+
+def _regex_allowed(masked: list[str], index: int) -> bool:
+    """Whether a `/` at `index` can start a regex literal rather than divide."""
+    cursor = index - 1
+    while cursor >= 0 and masked[cursor] in " \t\r\n":
+        cursor -= 1
+
+    if cursor < 0:
+        return True
+
+    char = masked[cursor]
+
+    if char in REGEX_PREV_PUNCTUATION:
+        return True
+
+    if char.isalnum() or char in "_$":
+        end = cursor + 1
+        while cursor >= 0 and (masked[cursor].isalnum() or masked[cursor] in "_$"):
+            cursor -= 1
+
+        return "".join(masked[cursor + 1 : end]) in REGEX_PREV_KEYWORDS
+
+    return False
+
+
+class _SourceMasker:
+    """Blanks comment, string, template and regex spans while keeping offsets.
+
+    Brace and paren matching runs on the mask, so a `}` inside a string or a
+    comment can never terminate a handler body. Newlines survive masking, so line
+    numbers still line up with the original source. Template interpolations keep
+    their braces: `${` becomes ` {`, which balances against the closing `}`.
+    """
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+        self.out = list(source)
+        self.length = len(source)
+        self.index = 0
+        self.in_template = False
+        self.brace_depth = 0
+        self.interpolation_depths: list[int] = []
+
+    def run(self) -> str:
+        while self.index < self.length:
+            if self.in_template:
+                self._consume_template_char()
+            else:
+                self._consume_code_char()
+
+        return "".join(self.out)
+
+    def _blank(self, start: int, end: int) -> None:
+        for cursor in range(start, min(end, self.length)):
+            if self.out[cursor] != "\n":
+                self.out[cursor] = " "
+
+    def _peek(self) -> str:
+        return self.source[self.index + 1] if self.index + 1 < self.length else ""
+
+    def _consume_template_char(self) -> None:
+        char = self.source[self.index]
+
+        if char == "\\":
+            self._blank(self.index, self.index + 2)
+            self.index += 2
+        elif char == "`":
+            self._blank(self.index, self.index + 1)
+            self.in_template = False
+            self.index += 1
+        elif char == "$" and self._peek() == "{":
+            self._enter_interpolation()
+        else:
+            self._blank(self.index, self.index + 1)
+            self.index += 1
+
+    def _consume_code_char(self) -> None:
+        char = self.source[self.index]
+        following = self._peek()
+
+        if char == "/" and following == "/":
+            self._skip_line_comment()
+        elif char == "/" and following == "*":
+            self._skip_block_comment()
+        elif char in "'\"":
+            self._skip_quoted(char)
+        elif char == "`":
+            self._enter_template()
+        elif char == "/" and _regex_allowed(self.out, self.index):
+            self._skip_regex()
+        else:
+            self._track_brace(char)
+            self.index += 1
+
+    def _enter_interpolation(self) -> None:
+        # Only the `$` is blanked: the `{` has to survive so it balances against
+        # the `}` that closes the interpolation.
+        self._blank(self.index, self.index + 1)
+        self.interpolation_depths.append(self.brace_depth)
+        self.brace_depth += 1
+        self.in_template = False
+        self.index += 2
+
+    def _enter_template(self) -> None:
+        self._blank(self.index, self.index + 1)
+        self.in_template = True
+        self.index += 1
+
+    def _skip_line_comment(self) -> None:
+        end = self.source.find("\n", self.index)
+        end = self.length if end == -1 else end
+        self._blank(self.index, end)
+        self.index = end
+
+    def _skip_block_comment(self) -> None:
+        end = self.source.find("*/", self.index + 2)
+        end = self.length if end == -1 else end + 2
+        self._blank(self.index, end)
+        self.index = end
+
+    def _skip_quoted(self, quote: str) -> None:
+        cursor = self.index + 1
+        while cursor < self.length:
+            char = self.source[cursor]
+            if char == "\\":
+                cursor += 2
+                continue
+            if char in (quote, "\n"):
+                break
+            cursor += 1
+
+        self._blank(self.index, cursor + 1)
+        self.index = cursor + 1
+
+    def _skip_regex(self) -> None:
+        cursor = self.index + 1
+        in_character_class = False
+
+        while cursor < self.length:
+            char = self.source[cursor]
+            if char == "\\":
+                cursor += 2
+                continue
+            if char == "\n":
+                break
+            if char == "[":
+                in_character_class = True
+            elif char == "]":
+                in_character_class = False
+            elif char == "/" and not in_character_class:
+                cursor += 1
+                while cursor < self.length and self.source[cursor].isalpha():
+                    cursor += 1
+                break
+            cursor += 1
+
+        self._blank(self.index, cursor)
+        self.index = cursor
+
+    def _track_brace(self, char: str) -> None:
+        if char == "{":
+            self.brace_depth += 1
+        elif char == "}":
+            self.brace_depth -= 1
+            if (
+                self.interpolation_depths
+                and self.brace_depth == self.interpolation_depths[-1]
+            ):
+                self.interpolation_depths.pop()
+                self.in_template = True
+
+
+def mask_source(source: str) -> str:
+    return _SourceMasker(source).run()
+
+
+def match_delimiter(masked: str, start: int) -> int:
+    """Index of the delimiter closing the one at `start`, or -1 if unbalanced."""
+    pairs = {"{": "}", "(": ")", "[": "]"}
+    opener = masked[start]
+    closer = pairs[opener]
+    depth = 0
+
+    for index in range(start, len(masked)):
+        char = masked[index]
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return index
+
+    return -1
+
+
+# --------------------------------------------------------------------------- #
+# Classification
+# --------------------------------------------------------------------------- #
+
+
+def normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def classify(masked_body: str) -> str:
+    """Bucket a handler body into covered / insufficient / missing.
+
+    Runs on the masked body so that the word "error" inside a message string
+    cannot pass as error context.
+    """
+    log_calls = list(LOG_CALL_RE.finditer(masked_body))
+
+    for call in log_calls:
+        args_start = call.end() - 1
+        args_end = match_delimiter(masked_body, args_start)
+        args = masked_body[args_start : args_end + 1 if args_end != -1 else len(masked_body)]
+        if ERROR_CONTEXT_RE.search(args):
+            return STATUS_COVERED
+
+    # A rethrow reaches the @vtex/api unhandled-error path, so the failure is
+    # never silent even without a log call of its own.
+    if RETHROW_RE.search(masked_body):
+        return STATUS_COVERED
+
+    return STATUS_INSUFFICIENT if log_calls else STATUS_MISSING
+
+
+def is_suppressed(source: str, line: int) -> bool:
+    """True when the handler line or the line above carries the opt-out marker."""
+    lines = source.splitlines()
+    window = lines[max(0, line - 2) : line]
+
+    return any(SUPPRESSION_MARKER in candidate for candidate in window)
+
+
+def scan_file(path: Path, relative: str) -> list[dict]:
+    source = path.read_text(encoding="utf-8", errors="replace")
+    masked = mask_source(source)
+    handlers: list[dict] = []
+
+    candidates: list[tuple[int, str, str]] = []
+    for match in CATCH_BLOCK_RE.finditer(masked):
+        candidates.append((match.start(), "catch-block", "{"))
+    for match in DOT_CATCH_RE.finditer(masked):
+        candidates.append((match.start(), "promise-catch", "("))
+
+    for start, kind, opener in sorted(candidates):
+        delimiter = masked.index(opener, start)
+        end = match_delimiter(masked, delimiter)
+        if end == -1:
+            continue
+
+        body = source[delimiter + 1 : end]
+        masked_body = masked[delimiter + 1 : end]
+        line = source.count("\n", 0, start) + 1
+
+        if is_suppressed(source, line):
+            continue
+
+        handlers.append(
+            {
+                "file": relative,
+                "line": line,
+                "kind": kind,
+                "status": classify(masked_body),
+                "snippet": normalize(body)[:140],
+                "_fingerprint": normalize(body),
+            }
+        )
+
+    return handlers
+
+
+def assign_ids(handlers: list[dict]) -> None:
+    """Give every handler an id that survives unrelated line shifts.
+
+    The id hashes file + kind + normalized body instead of the line number, so
+    editing code above a finding does not read as a new finding. Identical bodies
+    in one file are disambiguated by their order of appearance.
+    """
+    seen: dict[str, int] = {}
+
+    for handler in handlers:
+        seed = f"{handler['file']}|{handler['kind']}|{handler.pop('_fingerprint')}"
+        digest = hashlib.sha1(seed.encode("utf-8")).hexdigest()[:12]
+        occurrence = seen.get(digest, 0) + 1
+        seen[digest] = occurrence
+        handler["id"] = digest if occurrence == 1 else f"{digest}-{occurrence}"
+
+
+def resolve_files(scope: tuple[str, ...]) -> list[Path]:
+    files: set[Path] = set()
+
+    for pattern in scope:
+        for path in REPO_ROOT.glob(pattern):
+            if not path.is_file():
+                continue
+            if any(part in EXCLUDED_PARTS for part in path.relative_to(REPO_ROOT).parts):
+                continue
+            files.add(path)
+
+    return sorted(files)
+
+
+def scan(scope: tuple[str, ...] | None = None) -> dict:
+    scope = SCOPE if scope is None else tuple(scope)
+    handlers: list[dict] = []
+
+    for path in resolve_files(scope):
+        handlers.extend(scan_file(path, path.relative_to(REPO_ROOT).as_posix()))
+
+    handlers.sort(key=lambda handler: (handler["file"], handler["line"]))
+    assign_ids(handlers)
+
+    counts = {
+        STATUS_COVERED: 0,
+        STATUS_INSUFFICIENT: 0,
+        STATUS_MISSING: 0,
+    }
+    for handler in handlers:
+        counts[handler["status"]] += 1
+
+    total = len(handlers)
+    percent = round(counts[STATUS_COVERED] / total * 100, 1) if total else 0.0
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "scope": list(scope),
+        "score": {
+            "covered": counts[STATUS_COVERED],
+            "insufficient": counts[STATUS_INSUFFICIENT],
+            "missing": counts[STATUS_MISSING],
+            "total": total,
+            "percent": percent,
+        },
+        "handlers": [
+            {key: handler[key] for key in ("id", "file", "line", "kind", "status", "snippet")}
+            for handler in handlers
+        ],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Comparison
+# --------------------------------------------------------------------------- #
+
+EMPTY_METRICS = {
+    "schemaVersion": SCHEMA_VERSION,
+    "scope": [],
+    "score": {
+        "covered": 0,
+        "insufficient": 0,
+        "missing": 0,
+        "total": 0,
+        "percent": 0.0,
+    },
+    "handlers": [],
+}
+
+
+def compare(baseline: dict, current: dict) -> dict:
+    before = {handler["id"]: handler for handler in baseline.get("handlers", [])}
+    after = {handler["id"]: handler for handler in current.get("handlers", [])}
+
+    regressed = [
+        handler
+        for handler_id, handler in after.items()
+        if handler["status"] != STATUS_COVERED
+        and (handler_id not in before or before[handler_id]["status"] == STATUS_COVERED)
+    ]
+    resolved = [
+        handler
+        for handler_id, handler in before.items()
+        if handler["status"] != STATUS_COVERED
+        and (handler_id not in after or after[handler_id]["status"] == STATUS_COVERED)
+    ]
+
+    regressed.sort(key=lambda handler: (handler["file"], handler["line"]))
+    resolved.sort(key=lambda handler: (handler["file"], handler["line"]))
+
+    return {
+        "baselineScore": baseline.get("score", EMPTY_METRICS["score"]),
+        "currentScore": current["score"],
+        "percentDelta": round(
+            current["score"]["percent"]
+            - baseline.get("score", EMPTY_METRICS["score"])["percent"],
+            1,
+        ),
+        "regressed": regressed,
+        "resolved": resolved,
+    }
+
+
+def read_baseline_from_ref(ref: str) -> dict | None:
+    """Read the baseline as committed on `ref`, so re-runs stay idempotent."""
+    try:
+        blob = subprocess.run(
+            ["git", "show", f"{ref}:{BASELINE_PATH.as_posix()}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+    try:
+        return json.loads(blob)
+    except json.JSONDecodeError:
+        return None
+
+
+class ConfigError(RuntimeError):
+    """Raised when .log-coverage.json is missing, malformed, or has no scope."""
+
+
+def find_repo_root(explicit: str | None = None) -> Path:
+    """Locate the repository root without depending on where this file sits.
+
+    Deriving it from `__file__` would hardcode the script's install path, which
+    is exactly the coupling that makes a scorer non-portable.
+    """
+    if explicit:
+        return Path(explicit).resolve()
+
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        if top:
+            return Path(top)
+    except (subprocess.CalledProcessError, OSError):
+        pass
+
+    return Path.cwd()
+
+
+def load_config(repo_root: Path) -> dict:
+    path = repo_root / CONFIG_FILENAME
+
+    if not path.is_file():
+        raise ConfigError(
+            f"{CONFIG_FILENAME} not found at {repo_root}. "
+            "Run the log-coverage-setup skill to create it."
+        )
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ConfigError(f"{CONFIG_FILENAME} is not valid JSON: {error}") from error
+
+    if not isinstance(raw, dict):
+        raise ConfigError(f"{CONFIG_FILENAME} must contain a JSON object.")
+
+    scope = raw.get("scope")
+    # No default scope: guessing a layout would silently scan nothing and report
+    # a meaningless 0/0. Every repo declares its own audited surface.
+    if not isinstance(scope, list) or not scope:
+        raise ConfigError(
+            f"{CONFIG_FILENAME} must declare a non-empty \"scope\" array of globs, "
+            'e.g. ["node/clients/**/*.ts", "node/middlewares/**/*.ts"].'
+        )
+
+    return {**CONFIG_DEFAULTS, **raw}
+
+
+def configure(repo_root_arg: str | None = None) -> dict:
+    """Bind the repository-specific globals from .log-coverage.json."""
+    global REPO_ROOT, SCOPE, EXCLUDED_PARTS
+    global BASELINE_PATH, REPORTS_DIR, JUDGED_AUDIT_GLOBS, REPORT_TRIGGERS
+    global REPORT_COMMAND, DOCS_PATH
+
+    REPO_ROOT = find_repo_root(repo_root_arg)
+    config = load_config(REPO_ROOT)
+
+    SCOPE = tuple(config["scope"])
+    EXCLUDED_PARTS = tuple(config["exclude"])
+    BASELINE_PATH = Path(config["baseline"])
+    REPORTS_DIR = Path(config["reportsDir"])
+    JUDGED_AUDIT_GLOBS = tuple(config["judgedAuditGlobs"])
+    REPORT_TRIGGERS = tuple(config["reportTriggers"])
+    REPORT_COMMAND = config["reportCommand"]
+    DOCS_PATH = config["docsPath"]
+
+    return config
+
+
+@functools.lru_cache(maxsize=256)
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a glob into a regex with the same semantics as `Path.glob`.
+
+    `PurePath.match` cannot be used here: it treats `**` as `*` and is not
+    recursive, so `node/clients/**/*.ts` would fail to match a direct child like
+    `node/clients/lm.ts`. That mismatch is invisible with shallow globs and
+    silently opens a hole in the gate as soon as a scope uses `**`.
+    """
+    out: list[str] = []
+    index = 0
+
+    while index < len(pattern):
+        if pattern.startswith("**/", index):
+            out.append("(?:[^/]+/)*")
+            index += 3
+        elif pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        elif pattern[index] == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(pattern[index]))
+            index += 1
+
+    return re.compile(f"^{''.join(out)}$")
+
+
+def matches_any(path: str, patterns: Iterable[str]) -> bool:
+    """True when `path` is inside the audited surface.
+
+    Excluded directories are applied here as well, so a broad scope such as
+    `node/**/*.ts` treats `node/__tests__/x.test.ts` the same way the scanner
+    does — skipped, not audited.
+    """
+    if any(part in EXCLUDED_PARTS for part in PurePosixPath(path).parts):
+        return False
+
+    return any(glob_to_regex(pattern).match(path) for pattern in patterns)
+
+
+def changed_files(ref: str) -> list[str] | None:
+    """Paths changed since the merge base with `ref`, or None if git can't tell."""
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "--name-only", f"{ref}...HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+    return [line for line in diff.splitlines() if line]
+
+
+def report_requirement(diff_ref: str | None, scope: Iterable[str]) -> tuple[bool, str]:
+    """Whether this branch has to carry a report, and why.
+
+    Without a diff ref (local runs) the report is always required. With one, it is
+    required only when the change actually touches audited code — a docs-only PR
+    has nothing to record. If git cannot produce the diff we fail closed and ask
+    for the report, so a shallow clone can never quietly disable the gate.
+    """
+    if not diff_ref:
+        return True, "run without a diff ref"
+
+    changed = changed_files(diff_ref)
+    if changed is None:
+        return True, f"could not diff against `{diff_ref}`"
+
+    audited = [path for path in changed if matches_any(path, tuple(scope))]
+    tooling = [path for path in changed if matches_any(path, REPORT_TRIGGERS)]
+
+    if audited:
+        noun = "file" if len(audited) == 1 else "files"
+
+        return True, f"{len(audited)} audited {noun} changed"
+
+    # Reported separately: "audited file changed" would send the developer looking
+    # for a source change that is not in the diff.
+    if tooling:
+        return True, f"the scorer changed (`{tooling[0]}`)"
+
+    return False, "no audited file changed"
+
+
+def evaluate_report(pr: str, metrics: dict, required: bool, reason: str) -> tuple[str, str]:
+    """Classify the committed report as not-required / missing / stale / fresh."""
+    path = REPO_ROOT / REPORTS_DIR / f"pr-{pr}" / "metrics.json"
+    expected = f"`{REPORTS_DIR.as_posix()}/pr-{pr}/metrics.json`"
+    regenerate = f"Run `{report_command(pr)}` and commit the result."
+
+    if not required:
+        return (
+            REPORT_NOT_REQUIRED,
+            f"Not required — {reason}, so there is nothing to record.",
+        )
+
+    if not path.is_file():
+        return (
+            REPORT_MISSING,
+            f"**Missing** — {expected} is not committed ({reason}). {regenerate}",
+        )
+
+    # Compared parsed, not byte-for-byte: the report command may run the written
+    # JSON through Prettier, which reflows short arrays.
+    if json.loads(path.read_text(encoding="utf-8")) != metrics:
+        return (
+            REPORT_STALE,
+            f"**Stale** — {expected} does not match a fresh scan of this branch. "
+            f"{regenerate}",
+        )
+
+    return REPORT_FRESH, f"Up to date — {expected} matches this branch."
+
+
+def resolve_baseline(ref: str | None) -> tuple[dict, str]:
+    if ref:
+        from_ref = read_baseline_from_ref(ref)
+        if from_ref is not None:
+            return from_ref, ref
+
+    on_disk = REPO_ROOT / BASELINE_PATH
+    if on_disk.is_file():
+        return json.loads(on_disk.read_text(encoding="utf-8")), "working tree"
+
+    return dict(EMPTY_METRICS), "none"
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def format_score(score: dict) -> str:
+    return (
+        f"{score['covered']}/{score['total']} = {score['percent']}% "
+        f"(missing {score['missing']}, insufficient {score['insufficient']})"
+    )
+
+
+def render_table(handlers: list[dict]) -> str:
+    if not handlers:
+        return "_none_\n"
+
+    rows = ["| file:line | kind | status | body |", "|---|---|---|---|"]
+    for handler in handlers:
+        body = handler["snippet"].replace("|", "\\|")
+        rows.append(
+            f"| `{handler['file']}:{handler['line']}` | {handler['kind']} "
+            f"| **{handler['status']}** | `{body}` |"
+        )
+
+    return "\n".join(rows) + "\n"
+
+
+def link_from_report(pr: str | None, target: Path) -> str:
+    """Relative link from a per-PR report folder to a repo path.
+
+    Computed rather than hardcoded, because `reportsDir` is configurable and need
+    not sit under `docs/`.
+    """
+    report_dir = REPO_ROOT / REPORTS_DIR / f"pr-{pr}"
+
+    return PurePosixPath(
+        os.path.relpath(REPO_ROOT / target, report_dir)
+    ).as_posix()
+
+
+def judged_audit_note(pr: str | None = None) -> str:
+    audits: list[Path] = []
+    for pattern in JUDGED_AUDIT_GLOBS:
+        audits.extend(path for path in REPO_ROOT.glob(pattern) if path.is_file())
+
+    if not audits:
+        return ""
+
+    links = ", ".join(
+        f"[`{path.name}`]({link_from_report(pr, path.relative_to(REPO_ROOT))})"
+        # Keyed on the stem, not the name: the `.md` suffix sorts after the `-r2`
+        # revision marker, which would list a superseded audit ahead of the current one.
+        for path in sorted(set(audits), key=lambda path: path.stem, reverse=True)[:3]
+    )
+
+    return f" Judged audits: {links}."
+
+
+def docs_note(pr: str | None = None) -> str:
+    if not DOCS_PATH:
+        return ""
+
+    return f" See [`{DOCS_PATH}`]({link_from_report(pr, Path(DOCS_PATH))})."
+
+
+def render_delta_section(delta: dict, baseline_origin: str) -> str:
+    arrow = "no change"
+    if delta["percentDelta"] > 0:
+        arrow = f"up {delta['percentDelta']} pp"
+    elif delta["percentDelta"] < 0:
+        arrow = f"down {abs(delta['percentDelta'])} pp"
+
+    lines = [
+        f"- **Baseline** ({baseline_origin}): {format_score(delta['baselineScore'])}",
+        f"- **This branch**: {format_score(delta['currentScore'])}",
+        f"- **Delta**: {arrow}",
+        "",
+        f"### New or regressed ({len(delta['regressed'])})",
+        "",
+        render_table(delta["regressed"]),
+        f"### Resolved or removed ({len(delta['resolved'])})",
+        "",
+        render_table(delta["resolved"]),
+    ]
+
+    return "\n".join(lines)
+
+
+def render_report(pr: str, metrics: dict, delta: dict, baseline_origin: str) -> str:
+    findings = [
+        handler for handler in metrics["handlers"] if handler["status"] != STATUS_COVERED
+    ]
+
+    return "\n".join(
+        [
+            f"# Log coverage — PR #{pr}",
+            "",
+            f"**Date:** {date.today().isoformat()}  ",
+            f"**Scope:** {', '.join(f'`{pattern}`' for pattern in metrics['scope'])}  ",
+            f"**Score:** {format_score(metrics['score'])}",
+            "",
+            "Deterministic proxy metric over `try/catch` and `.catch(...)` handlers. "
+            "It is not a model-judged audit score, which also weighs validation "
+            "aborts and cross-function context."
+            f"{judged_audit_note(pr)}{docs_note(pr)}",
+            "",
+            "## Delta",
+            "",
+            render_delta_section(delta, baseline_origin),
+            f"## All open findings ({len(findings)})",
+            "",
+            render_table(findings),
+        ]
+    )
+
+
+def render_comment(
+    pr: str | None,
+    metrics: dict,
+    delta: dict,
+    baseline_origin: str,
+    state: str,
+    message: str,
+) -> str:
+    verdict = (
+        "This check is **failing** until the report is committed."
+        if state in BLOCKING_REPORT_STATES
+        else "This check is **passing**."
+    )
+
+    return "\n".join(
+        [
+            COMMENT_MARKER,
+            "## Log coverage",
+            "",
+            f"Deterministic proxy metric — **{format_score(metrics['score'])}**. "
+            "The score itself never blocks: a regression is a review signal, not a "
+            "failure. What blocks is a missing or stale report.",
+            "",
+            render_delta_section(delta, baseline_origin),
+            "### Committed report",
+            "",
+            f"{message} {verdict}",
+            "",
+            f"<sub>Regenerate with `{report_command(pr)}`.</sub>",
+        ]
+    )
+
+
+def render_text(metrics: dict) -> str:
+    score = metrics["score"]
+    lines = [
+        f"log coverage (deterministic proxy)  covered {format_score(score)}",
+        "",
+    ]
+
+    findings = [
+        handler for handler in metrics["handlers"] if handler["status"] != STATUS_COVERED
+    ]
+    if not findings:
+        lines.append("no findings")
+    else:
+        lines.append(f"findings ({len(findings)}):")
+        for handler in findings:
+            lines.append(
+                f"  {handler['file']}:{handler['line']}  "
+                f"{handler['status']:<12} {handler['kind']:<14} {handler['snippet'][:60]}"
+            )
+
+    return "\n".join(lines)
+
+
+def dump_json(payload: dict) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Commands
+# --------------------------------------------------------------------------- #
+
+
+def command_scan(args: argparse.Namespace) -> int:
+    metrics = scan()
+    sys.stdout.write(
+        dump_json(metrics) if args.format == "json" else render_text(metrics) + "\n"
+    )
+
+    return 0
+
+
+def command_report(args: argparse.Namespace) -> int:
+    metrics = scan()
+    baseline, baseline_origin = resolve_baseline(args.baseline_ref)
+    delta = compare(baseline, metrics)
+
+    report_dir = REPO_ROOT / REPORTS_DIR / f"pr-{args.pr}"
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    # metrics.json holds no timestamp on purpose: CI compares it byte-for-byte
+    # against a fresh scan to tell whether the committed report is stale.
+    (report_dir / "metrics.json").write_text(dump_json(metrics), encoding="utf-8")
+    (report_dir / "report.md").write_text(
+        render_report(args.pr, metrics, delta, baseline_origin), encoding="utf-8"
+    )
+    (REPO_ROOT / BASELINE_PATH).write_text(dump_json(metrics), encoding="utf-8")
+
+    print(f"wrote {REPORTS_DIR / f'pr-{args.pr}'}/report.md")
+    print(f"wrote {REPORTS_DIR / f'pr-{args.pr}'}/metrics.json")
+    print(f"refreshed {BASELINE_PATH}")
+    print()
+    print(render_text(metrics))
+
+    return 0
+
+
+def command_check(args: argparse.Namespace) -> int:
+    metrics = scan()
+    baseline, baseline_origin = resolve_baseline(args.baseline_ref)
+    delta = compare(baseline, metrics)
+
+    required, reason = report_requirement(args.diff_ref, metrics["scope"])
+    state, message = evaluate_report(args.pr, metrics, required, reason)
+
+    body = (
+        render_comment(args.pr, metrics, delta, baseline_origin, state, message) + "\n"
+    )
+
+    if args.markdown_out:
+        Path(args.markdown_out).write_text(body, encoding="utf-8")
+    else:
+        sys.stdout.write(body)
+
+    blocking = state in BLOCKING_REPORT_STATES
+
+    if blocking:
+        print(f"log-coverage report {state}: {reason}", file=sys.stderr)
+
+    return 1 if blocking and args.strict else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        help="repository root; defaults to `git rev-parse --show-toplevel`",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    scan_parser = subparsers.add_parser("scan", help="print metrics for the scope")
+    scan_parser.add_argument("--format", choices=("json", "text"), default="text")
+    scan_parser.set_defaults(handler=command_scan)
+
+    report_parser = subparsers.add_parser("report", help="write the per-PR report")
+    report_parser.add_argument("--pr", required=True, help="pull request number")
+    report_parser.add_argument("--baseline-ref", default="origin/main")
+    report_parser.set_defaults(handler=command_report)
+
+    check_parser = subparsers.add_parser("check", help="gate on the committed report")
+    check_parser.add_argument("--pr", required=True, help="pull request number")
+    check_parser.add_argument("--baseline-ref", default="origin/main")
+    check_parser.add_argument(
+        "--diff-ref",
+        help="require a report only when the change touches audited files, "
+        "measured against this ref; omit to always require one",
+    )
+    check_parser.add_argument("--markdown-out")
+    check_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero when a required report is missing or stale",
+    )
+    check_parser.set_defaults(handler=command_check)
+
+    args = parser.parse_args()
+
+    try:
+        configure(args.repo_root)
+    except ConfigError as error:
+        print(f"log-coverage: {error}", file=sys.stderr)
+
+        return 2
+
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/log_coverage/test_audit.py
+++ b/scripts/log_coverage/test_audit.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Unit tests for the deterministic log-coverage scorer.
+
+The score gates nothing, but it feeds a committed baseline — so the classifier
+has to stay honest. These tests pin the judgment calls that are easy to break:
+brace matching through strings and templates, error context that must not be
+satisfied by a message string, and finding ids that survive line shifts.
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+import audit
+
+# A representative scope, not any particular app's. The scorer must not assume a
+# repository layout, so the tests must not either.
+SCOPE = ("node/clients/**/*.ts", "node/middlewares/**/*.ts")
+TRIGGERS = ("scripts/log_coverage/audit.py",)
+
+
+def scan_snippet(source: str) -> list[dict]:
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory) / "sample.ts"
+        path.write_text(source, encoding="utf-8")
+        handlers = audit.scan_file(path, "sample.ts")
+
+    audit.assign_ids(handlers)
+
+    return handlers
+
+
+class MaskSourceTest(unittest.TestCase):
+    def test_preserves_offsets_and_newlines(self) -> None:
+        source = "const a = 'xy'\n// comment\n"
+        masked = audit.mask_source(source)
+
+        self.assertEqual(len(masked), len(source))
+        self.assertEqual(masked.count("\n"), source.count("\n"))
+
+    def test_blanks_braces_inside_strings(self) -> None:
+        masked = audit.mask_source("const a = '}'")
+
+        self.assertNotIn("}", masked)
+
+    def test_blanks_braces_inside_comments(self) -> None:
+        masked = audit.mask_source("// }\n/* } */")
+
+        self.assertNotIn("}", masked)
+
+    def test_keeps_template_interpolation_braces_balanced(self) -> None:
+        masked = audit.mask_source("const a = `x ${ y } z`")
+
+        self.assertEqual(masked.count("{"), 1)
+        self.assertEqual(masked.count("}"), 1)
+
+    def test_blanks_template_text_but_not_interpolated_code(self) -> None:
+        masked = audit.mask_source("const a = `lit ${error} lit`")
+
+        self.assertIn("error", masked)
+        self.assertNotIn("lit", masked)
+
+    def test_blanks_regex_literal_content(self) -> None:
+        masked = audit.mask_source("const a = /}{/.test(b)")
+
+        self.assertNotIn("}", masked)
+        self.assertIn(".test(b)", masked)
+
+    def test_division_is_not_treated_as_regex(self) -> None:
+        source = "const a = (b) / c\nconst d = { e: 1 }"
+        masked = audit.mask_source(source)
+
+        self.assertIn("{ e: 1 }", masked)
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_log_with_error_object_is_covered(self) -> None:
+        body = "logger.warn({ message: 'nope', error: error.message })"
+
+        self.assertEqual(audit.classify(body), audit.STATUS_COVERED)
+
+    def test_nested_logger_path_is_recognized(self) -> None:
+        body = "ctx.vtex.logger.error({ err })"
+
+        self.assertEqual(audit.classify(body), audit.STATUS_COVERED)
+
+    def test_rethrow_is_covered_even_without_a_log(self) -> None:
+        body = "throw new UserInputError('bad')"
+
+        self.assertEqual(audit.classify(body), audit.STATUS_COVERED)
+
+    def test_log_without_error_context_is_insufficient(self) -> None:
+        body = "logger.warn({ message: 'something happened', unitId })"
+
+        self.assertEqual(audit.classify(body), audit.STATUS_INSUFFICIENT)
+
+    def test_error_word_inside_a_message_string_does_not_count(self) -> None:
+        source = "try { a() } catch { logger.warn({ message: 'error parsing' }) }"
+        handlers = scan_snippet(source)
+
+        self.assertEqual(handlers[0]["status"], audit.STATUS_INSUFFICIENT)
+
+    def test_silent_swallow_is_missing(self) -> None:
+        body = "return null"
+
+        self.assertEqual(audit.classify(body), audit.STATUS_MISSING)
+
+
+class ScanFileTest(unittest.TestCase):
+    def test_detects_bare_catch_binding_and_promise_catch(self) -> None:
+        source = (
+            "try { a() } catch { return null }\n"
+            "try { b() } catch (error) { logger.error({ error }) }\n"
+            "c().catch(() => null)\n"
+        )
+        handlers = scan_snippet(source)
+
+        self.assertEqual(
+            [(handler["line"], handler["kind"], handler["status"]) for handler in handlers],
+            [
+                (1, "catch-block", audit.STATUS_MISSING),
+                (2, "catch-block", audit.STATUS_COVERED),
+                (3, "promise-catch", audit.STATUS_MISSING),
+            ],
+        )
+
+    def test_promise_catch_with_block_body_is_classified(self) -> None:
+        source = "c().catch((err) => {\n  logger.warn({ err })\n})\n"
+        handlers = scan_snippet(source)
+
+        self.assertEqual(handlers[0]["status"], audit.STATUS_COVERED)
+
+    def test_marker_on_the_handler_line_suppresses_it(self) -> None:
+        source = "try { a() } catch { return null } // log-coverage-ignore: pure predicate\n"
+
+        self.assertEqual(scan_snippet(source), [])
+
+    def test_marker_on_the_line_above_suppresses_it(self) -> None:
+        source = "// log-coverage-ignore: pure predicate\ntry { a() } catch { return null }\n"
+
+        self.assertEqual(scan_snippet(source), [])
+
+    def test_brace_in_a_string_does_not_end_the_handler_body(self) -> None:
+        source = "try { a() } catch {\n  logger.warn({ message: '}', error })\n}\n"
+        handlers = scan_snippet(source)
+
+        self.assertEqual(len(handlers), 1)
+        self.assertEqual(handlers[0]["status"], audit.STATUS_COVERED)
+
+
+class FindingIdTest(unittest.TestCase):
+    def test_id_survives_unrelated_lines_added_above(self) -> None:
+        body = "try { a() } catch { return null }\n"
+        original = scan_snippet(body)
+        shifted = scan_snippet("const x = 1\nconst y = 2\n" + body)
+
+        self.assertNotEqual(original[0]["line"], shifted[0]["line"])
+        self.assertEqual(original[0]["id"], shifted[0]["id"])
+
+    def test_identical_bodies_in_one_file_get_distinct_ids(self) -> None:
+        source = "try { a() } catch { return null }\ntry { b() } catch { return null }\n"
+        handlers = scan_snippet(source)
+
+        self.assertEqual(len({handler["id"] for handler in handlers}), 2)
+
+
+class CompareTest(unittest.TestCase):
+    @staticmethod
+    def metrics(*handlers: dict) -> dict:
+        payload = dict(audit.EMPTY_METRICS)
+        payload["handlers"] = list(handlers)
+        covered = sum(1 for handler in handlers if handler["status"] == "covered")
+        payload["score"] = {
+            "covered": covered,
+            "insufficient": 0,
+            "missing": len(handlers) - covered,
+            "total": len(handlers),
+            "percent": round(covered / len(handlers) * 100, 1) if handlers else 0.0,
+        }
+
+        return payload
+
+    @staticmethod
+    def handler(handler_id: str, status: str) -> dict:
+        return {
+            "id": handler_id,
+            "file": "sample.ts",
+            "line": 1,
+            "kind": "catch-block",
+            "status": status,
+            "snippet": "",
+        }
+
+    def test_newly_uncovered_handler_is_reported_as_regressed(self) -> None:
+        delta = audit.compare(
+            self.metrics(self.handler("a", "covered")),
+            self.metrics(self.handler("a", "covered"), self.handler("b", "missing")),
+        )
+
+        self.assertEqual([handler["id"] for handler in delta["regressed"]], ["b"])
+        self.assertEqual(delta["resolved"], [])
+
+    def test_handler_that_gained_a_log_is_reported_as_resolved(self) -> None:
+        delta = audit.compare(
+            self.metrics(self.handler("a", "missing")),
+            self.metrics(self.handler("a", "covered")),
+        )
+
+        self.assertEqual([handler["id"] for handler in delta["resolved"]], ["a"])
+        self.assertEqual(delta["regressed"], [])
+
+    def test_deleted_uncovered_handler_counts_as_resolved(self) -> None:
+        delta = audit.compare(self.metrics(self.handler("a", "missing")), self.metrics())
+
+        self.assertEqual([handler["id"] for handler in delta["resolved"]], ["a"])
+
+    def test_percent_delta_is_signed(self) -> None:
+        delta = audit.compare(
+            self.metrics(self.handler("a", "missing")),
+            self.metrics(self.handler("a", "covered")),
+        )
+
+        self.assertEqual(delta["percentDelta"], 100.0)
+
+
+class GlobMatchingTest(unittest.TestCase):
+    """The matcher and the scanner must agree on what is in scope.
+
+    `PurePath.match` disagrees with `Path.glob` about `**`, which used to let a
+    change to a direct child slip past the gate while still moving the score.
+    """
+
+    def test_recursive_glob_matches_a_direct_child(self) -> None:
+        self.assertTrue(audit.matches_any("node/clients/lm.ts", ("node/clients/**/*.ts",)))
+
+    def test_recursive_glob_matches_a_nested_child(self) -> None:
+        self.assertTrue(
+            audit.matches_any("node/modules/users/svc.ts", ("node/modules/**/*.ts",))
+        )
+
+    def test_shallow_glob_rejects_a_nested_child(self) -> None:
+        self.assertFalse(
+            audit.matches_any("node/modules/users/svc.ts", ("node/modules/*.ts",))
+        )
+
+    def test_star_does_not_cross_directory_separators(self) -> None:
+        self.assertFalse(audit.matches_any("node/a/b.ts", ("node/*.ts",)))
+
+    def test_extension_is_respected(self) -> None:
+        self.assertFalse(audit.matches_any("node/clients/lm.tsx", ("node/clients/**/*.ts",)))
+
+    def test_excluded_directory_is_out_of_scope_under_a_broad_glob(self) -> None:
+        with unittest.mock.patch.object(audit, "EXCLUDED_PARTS", ("__tests__",)):
+            self.assertFalse(
+                audit.matches_any("node/__tests__/svc.test.ts", ("node/**/*.ts",))
+            )
+
+    def test_regex_metacharacters_in_paths_are_literal(self) -> None:
+        self.assertFalse(audit.matches_any("nodeXclients/lm.ts", ("node/clients/**/*.ts",)))
+
+
+class ReportRequirementTest(unittest.TestCase):
+    def test_audited_source_change_requires_a_report(self) -> None:
+        with unittest.mock.patch.object(
+            audit, "changed_files", return_value=["node/middlewares/enrich.ts"]
+        ):
+            required, reason = audit.report_requirement("origin/main", SCOPE)
+
+        self.assertTrue(required)
+        self.assertEqual(reason, "1 audited file changed")
+
+    def test_configured_trigger_requires_a_report(self) -> None:
+        with unittest.mock.patch.object(
+            audit, "changed_files", return_value=["scripts/log_coverage/audit.py"]
+        ), unittest.mock.patch.object(audit, "REPORT_TRIGGERS", TRIGGERS):
+            required, _ = audit.report_requirement("origin/main", SCOPE)
+
+        self.assertTrue(required)
+
+    def test_tooling_change_is_not_reported_as_an_audited_file(self) -> None:
+        with unittest.mock.patch.object(
+            audit, "changed_files", return_value=["scripts/log_coverage/audit.py"]
+        ), unittest.mock.patch.object(audit, "REPORT_TRIGGERS", TRIGGERS):
+            _, reason = audit.report_requirement("origin/main", SCOPE)
+
+        self.assertIn("scorer changed", reason)
+        self.assertNotIn("audited", reason)
+
+    def test_untriggered_tooling_change_does_not_require_a_report(self) -> None:
+        with unittest.mock.patch.object(
+            audit, "changed_files", return_value=["scripts/log_coverage/audit.py"]
+        ), unittest.mock.patch.object(audit, "REPORT_TRIGGERS", ()):
+            required, _ = audit.report_requirement("origin/main", SCOPE)
+
+        self.assertFalse(required)
+
+    def test_docs_only_change_does_not_require_a_report(self) -> None:
+        with unittest.mock.patch.object(
+            audit, "changed_files", return_value=["docs/README.md", "CHANGELOG.md"]
+        ):
+            required, reason = audit.report_requirement("origin/main", SCOPE)
+
+        self.assertFalse(required)
+        self.assertEqual(reason, "no audited file changed")
+
+    def test_test_file_change_does_not_require_a_report(self) -> None:
+        with unittest.mock.patch.object(
+            audit,
+            "changed_files",
+            return_value=["node/__tests__/enrich.test.ts"],
+        ):
+            required, _ = audit.report_requirement("origin/main", SCOPE)
+
+        self.assertFalse(required)
+
+    def test_unavailable_diff_fails_closed(self) -> None:
+        with unittest.mock.patch.object(audit, "changed_files", return_value=None):
+            required, reason = audit.report_requirement("origin/main", SCOPE)
+
+        self.assertTrue(required)
+        self.assertIn("could not diff", reason)
+
+    def test_no_diff_ref_always_requires_a_report(self) -> None:
+        required, _ = audit.report_requirement(None, SCOPE)
+
+        self.assertTrue(required)
+
+
+class EvaluateReportTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.metrics = {"score": {"covered": 1}, "handlers": []}
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        patcher = unittest.mock.patch.object(
+            audit, "REPO_ROOT", Path(self.directory.name)
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def write_committed(self, payload: dict) -> None:
+        path = Path(self.directory.name) / audit.REPORTS_DIR / "pr-1"
+        path.mkdir(parents=True)
+        (path / "metrics.json").write_text(audit.dump_json(payload), encoding="utf-8")
+
+    def test_not_required_when_nothing_audited_changed(self) -> None:
+        state, _ = audit.evaluate_report("1", self.metrics, False, "no audited file changed")
+
+        self.assertEqual(state, audit.REPORT_NOT_REQUIRED)
+        self.assertNotIn(state, audit.BLOCKING_REPORT_STATES)
+
+    def test_missing_report_blocks(self) -> None:
+        state, message = audit.evaluate_report("1", self.metrics, True, "1 audited file changed")
+
+        self.assertEqual(state, audit.REPORT_MISSING)
+        self.assertIn(state, audit.BLOCKING_REPORT_STATES)
+        self.assertIn(audit.report_command("1"), message)
+
+    def test_stale_report_blocks(self) -> None:
+        self.write_committed({"score": {"covered": 0}, "handlers": []})
+        state, _ = audit.evaluate_report("1", self.metrics, True, "1 audited file changed")
+
+        self.assertEqual(state, audit.REPORT_STALE)
+        self.assertIn(state, audit.BLOCKING_REPORT_STATES)
+
+    def test_matching_report_passes(self) -> None:
+        self.write_committed(self.metrics)
+        state, _ = audit.evaluate_report("1", self.metrics, True, "1 audited file changed")
+
+        self.assertEqual(state, audit.REPORT_FRESH)
+        self.assertNotIn(state, audit.BLOCKING_REPORT_STATES)
+
+    def test_prettier_reflowed_report_still_matches(self) -> None:
+        metrics = {"scope": ["a", "b"], "handlers": [], "score": {"covered": 0}}
+        path = Path(self.directory.name) / audit.REPORTS_DIR / "pr-1"
+        path.mkdir(parents=True)
+        # Prettier collapses short arrays onto one line; the parsed value is what
+        # has to match, not the bytes.
+        (path / "metrics.json").write_text(
+            '{ "scope": ["a", "b"], "handlers": [], "score": { "covered": 0 } }',
+            encoding="utf-8",
+        )
+        state, _ = audit.evaluate_report("1", metrics, True, "1 audited file changed")
+
+        self.assertEqual(state, audit.REPORT_FRESH)
+
+
+class TreeScanTest(unittest.TestCase):
+    """Scanning is exercised against a synthetic tree, never the host repo.
+
+    Asserting on the host repository's real score would make these tests pass or
+    fail depending on which app the scorer was copied into.
+    """
+
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+
+        nested = self.root / "node" / "modules" / "users"
+        nested.mkdir(parents=True)
+        (nested / "users.service.ts").write_text(
+            "try { a() } catch (e) { logger.error({ error: e }) }\n"
+            "try { b() } catch (e) { }\n",
+            encoding="utf-8",
+        )
+
+        tests = self.root / "node" / "modules" / "__tests__"
+        tests.mkdir()
+        (tests / "users.test.ts").write_text(
+            "try { a() } catch (e) { }\n", encoding="utf-8"
+        )
+
+        patcher = unittest.mock.patch.object(audit, "REPO_ROOT", self.root)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_deep_globs_reach_nested_directories(self) -> None:
+        metrics = audit.scan(("node/modules/**/*.ts",))
+
+        self.assertEqual(metrics["score"]["total"], 2)
+        self.assertEqual(metrics["score"]["covered"], 1)
+        self.assertEqual(metrics["score"]["missing"], 1)
+
+    def test_shallow_globs_do_not_reach_nested_directories(self) -> None:
+        metrics = audit.scan(("node/modules/*.ts",))
+
+        self.assertEqual(metrics["score"]["total"], 0)
+
+    def test_excluded_directories_are_skipped(self) -> None:
+        metrics = audit.scan(("node/modules/**/*.ts",))
+        files = {handler["file"] for handler in metrics["handlers"]}
+
+        self.assertNotIn("node/modules/__tests__/users.test.ts", files)
+
+    def test_scanning_is_deterministic(self) -> None:
+        first = audit.dump_json(audit.scan(("node/modules/**/*.ts",)))
+        second = audit.dump_json(audit.scan(("node/modules/**/*.ts",)))
+
+        self.assertEqual(first, second)
+
+    def test_totals_are_internally_consistent(self) -> None:
+        score = audit.scan(("node/modules/**/*.ts",))["score"]
+
+        self.assertEqual(
+            score["total"],
+            score["covered"] + score["insufficient"] + score["missing"],
+        )
+
+
+class ConfigTest(unittest.TestCase):
+    def setUp(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+
+    def write(self, payload: str) -> None:
+        (self.root / audit.CONFIG_FILENAME).write_text(payload, encoding="utf-8")
+
+    def test_missing_config_is_reported(self) -> None:
+        with self.assertRaises(audit.ConfigError) as caught:
+            audit.load_config(self.root)
+
+        self.assertIn(audit.CONFIG_FILENAME, str(caught.exception))
+
+    def test_malformed_config_is_reported(self) -> None:
+        self.write("{ not json")
+
+        with self.assertRaises(audit.ConfigError):
+            audit.load_config(self.root)
+
+    def test_missing_scope_is_rejected(self) -> None:
+        self.write('{"baseline": "docs/log-coverage/baseline.json"}')
+
+        with self.assertRaises(audit.ConfigError) as caught:
+            audit.load_config(self.root)
+
+        self.assertIn("scope", str(caught.exception))
+
+    def test_empty_scope_is_rejected(self) -> None:
+        self.write('{"scope": []}')
+
+        with self.assertRaises(audit.ConfigError):
+            audit.load_config(self.root)
+
+    def test_defaults_fill_omitted_keys(self) -> None:
+        self.write('{"scope": ["node/**/*.ts"]}')
+
+        config = audit.load_config(self.root)
+
+        self.assertEqual(config["baseline"], "docs/log-coverage/baseline.json")
+        self.assertEqual(config["reportTriggers"], [])
+        self.assertIn("node_modules", config["exclude"])
+
+    def test_explicit_values_override_defaults(self) -> None:
+        self.write(
+            '{"scope": ["src/**/*.ts"], "baseline": "ops/base.json", '
+            '"exclude": ["spec"], "reportTriggers": ["tools/audit.py"]}'
+        )
+
+        config = audit.load_config(self.root)
+
+        self.assertEqual(config["baseline"], "ops/base.json")
+        self.assertEqual(config["exclude"], ["spec"])
+        self.assertEqual(config["reportTriggers"], ["tools/audit.py"])
+
+    def test_configure_binds_module_globals(self) -> None:
+        self.write('{"scope": ["src/**/*.ts"], "reportsDir": "ops/reports"}')
+
+        try:
+            audit.configure(str(self.root))
+
+            self.assertEqual(audit.REPO_ROOT, self.root.resolve())
+            self.assertEqual(audit.SCOPE, ("src/**/*.ts",))
+            self.assertEqual(audit.REPORTS_DIR, Path("ops/reports"))
+        finally:
+            audit.SCOPE = ()
+
+    def test_explicit_repo_root_wins_over_git(self) -> None:
+        self.assertEqual(audit.find_repo_root(str(self.root)), self.root.resolve())
+
+    def test_report_command_defaults_to_the_script(self) -> None:
+        with unittest.mock.patch.object(
+            audit, "REPORT_COMMAND", audit.CONFIG_DEFAULTS["reportCommand"]
+        ):
+            self.assertEqual(
+                audit.report_command("7"),
+                "python3 scripts/log_coverage/audit.py report --pr 7",
+            )
+
+    def test_report_command_is_configurable(self) -> None:
+        with unittest.mock.patch.object(
+            audit, "REPORT_COMMAND", "make log-coverage-report PR={pr}"
+        ):
+            self.assertEqual(audit.report_command("7"), "make log-coverage-report PR=7")
+
+    def test_judged_audit_note_is_omitted_when_no_globs(self) -> None:
+        with unittest.mock.patch.object(audit, "JUDGED_AUDIT_GLOBS", ()):
+            self.assertEqual(audit.judged_audit_note("1"), "")
+
+    def test_a_revision_is_listed_ahead_of_the_audit_it_supersedes(self) -> None:
+        audits = self.root / "docs" / "audits"
+        audits.mkdir(parents=True)
+        (audits / "audit-2026-08-21.md").write_text("x", encoding="utf-8")
+        (audits / "audit-2026-08-21-r2.md").write_text("x", encoding="utf-8")
+
+        with unittest.mock.patch.object(audit, "REPO_ROOT", self.root), \
+            unittest.mock.patch.object(
+                audit, "JUDGED_AUDIT_GLOBS", ("docs/audits/*.md",)
+            ):
+            note = audit.judged_audit_note("1")
+
+        self.assertLess(note.index("-r2.md"), note.index("21.md"))
+
+    def test_docs_note_is_omitted_when_unset(self) -> None:
+        with unittest.mock.patch.object(audit, "DOCS_PATH", ""):
+            self.assertEqual(audit.docs_note("1"), "")
+
+    def test_links_are_relative_to_the_report_folder(self) -> None:
+        with unittest.mock.patch.object(audit, "REPO_ROOT", self.root), \
+            unittest.mock.patch.object(audit, "REPORTS_DIR", Path("docs/lc/reports")):
+            link = audit.link_from_report("9", Path("docs/audits/a.md"))
+
+        self.assertEqual(link, "../../../audits/a.md")
+
+    def test_links_work_outside_docs(self) -> None:
+        with unittest.mock.patch.object(audit, "REPO_ROOT", self.root), \
+            unittest.mock.patch.object(audit, "REPORTS_DIR", Path("ops/reports")):
+            link = audit.link_from_report("9", Path("docs/audits/a.md"))
+
+        self.assertEqual(link, "../../../docs/audits/a.md")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## O que é

Instala um scorer **determinístico** de cobertura de logs e um workflow `Log coverage` que bloqueia PRs que mexem em código auditado sem trazer um relatório atualizado.

Empilhado sobre #205 (as auditorias julgadas). Revisar aquele primeiro.

## Escopo auditado

`node/**/*.ts`, exceto testes, mocks, `dist`, `build` e `typings`. Score inicial: **68/93 = 73,1%** (25 achados `missing`, 0 `insufficient`).

## Esta não é a mesma métrica das auditorias de #205

As auditorias de #205 foram julgadas por um modelo e contam também abortos de validação, early returns e contexto que atravessa funções. Este scorer casa estrutura com regex e só enxerga `catch` e `.catch()` — resolução mais baixa de propósito, em troca de ser reproduzível byte a byte. Um score não corrige nem substitui o outro.

## O que trava e o que não trava

- **Trava:** PR que mexe em arquivo do escopo (ou em `scripts/log_coverage/audit.py`) sem o relatório atualizado daquele PR.
- **Trava:** teste do scorer quebrado.
- **Não trava:** o score cair. Regressão vira comentário para o revisor decidir.
- **Não trava:** PR só de docs ou config.

## Dependências novas

`python3` — provisionado no CI via `actions/setup-python`, e necessário localmente para gerar o relatório. Sem impacto no runtime do app.

## Como usar

```bash
make log-coverage                 # score e achados
make log-coverage-report PR=123   # gera o relatório do PR
make log-coverage-test            # testes do scorer
```

## Depois do merge

O check só passa a bloquear quando for marcado como obrigatório em **Settings → Branches → branch protection → Require status checks to pass**, selecionando **`Log coverage`**. Até lá ele reporta sem travar.

## Test plan

- [x] 64 testes do scorer passam localmente
- [x] `scan` retorna total plausível, sem testes nem código gerado nos achados
- [ ] O workflow roda verde neste PR com o relatório commitado

Made with [Cursor](https://cursor.com)